### PR TITLE
Allow `$pattern` to be set by `setPattern()` for FormMonthSelect

### DIFF
--- a/docs/book/helper/form-month-select.md
+++ b/docs/book/helper/form-month-select.md
@@ -21,3 +21,30 @@ echo $this->formMonthSelect($monthYear);
 // <select name="monthyear[month]"> ... </select>
 // <select name="monthyear[year]"> ... </select>
 ```
+
+## Advanced usage
+
+### Render each element individually
+
+This can be archived by passing a custom pattern via `setPattern()`:
+
+```php
+<div class="row">
+    <div class="col-lg-7">
+        <!-- Render the select field for month only -->
+        <?=
+            $this->formMonthSelect()
+            ->setPattern('MMMM')
+            ->render($element);
+        ?>
+    </div>
+    <div class="col-lg-5">
+        <!-- Render the select field for day only -->
+        <?=
+             $this->formMonthSelect()
+            ->setPattern('y')
+            ->render($element);
+        ?>
+    </div>
+</div>
+```

--- a/src/View/Helper/FormMonthSelect.php
+++ b/src/View/Helper/FormMonthSelect.php
@@ -194,6 +194,16 @@ class FormMonthSelect extends AbstractHelper
     }
 
     /**
+     * @param string $pattern
+     * @return self
+     */
+    public function setPattern($pattern)
+    {
+        $this->pattern = $pattern;
+        return $this;
+    }
+
+    /**
      * Set date formatter
      *
      * @param  int $dateType

--- a/test/View/Helper/FormMonthSelectTest.php
+++ b/test/View/Helper/FormMonthSelectTest.php
@@ -111,4 +111,13 @@ class FormMonthSelectTest extends CommonTestCase
 
         $this->assertEquals(12, count($elements[0]->getValueOptions()));
     }
+
+    public function testSetAndGetPattern()
+    {
+        $this->helper->setLocale('de_DE');
+        $this->assertSame('d. MMMM y', $this->helper->getPattern());
+
+        $this->helper->setPattern('test');
+        $this->assertSame('test', $this->helper->getPattern());
+    }
 }


### PR DESCRIPTION
Hello,

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

somehow I don't see a reason why it shouldn't be possible to pass the pattern to the FormMonthSelect view helper.

When allowing this its possible to add separators between elements easily:

```
<div class="row">
    <div class="col-lg-7">
        <?=
            $this->formMonthSelect()
            ->setPattern('MMMM')
            ->render($element);
        ?>
    </div>
    <div class="col-lg-5">
        <?=
             $this->formMonthSelect()
            ->setPattern('y')
            ->render($element);
        ?>
    </div>
</div>
```

I don't like to add any test or documentation for this, as this is a very simple change.