### PR TITLE
Fix for PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,9 @@ matrix:
     - php: 7.3
       env:
         - DEPS=latest
+    - php: 7.4
+      env:
+        - DEPS=latest
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
         "laminas/laminas-text": "^2.6",
         "laminas/laminas-validator": "^2.6",
         "laminas/laminas-view": "^2.6.2",
-        "phpunit/phpunit": "^5.7.23 || ^6.5.3"
+        "phpunit/phpunit": "^5.7.23 || ^6.5.3 || ^7.5"
     },
     "suggest": {
         "laminas/laminas-captcha": "^2.7.1, required for using CAPTCHA form elements",

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
         "laminas/laminas-text": "^2.6",
         "laminas/laminas-validator": "^2.6",
         "laminas/laminas-view": "^2.6.2",
-        "phpunit/phpunit": "^5.7.23 || ^6.5.3 || ^7.5"
+        "phpunit/phpunit": "^5.7.27 || ^6.5.14 || ^7.5.20"
     },
     "suggest": {
         "laminas/laminas-captcha": "^2.7.1, required for using CAPTCHA form elements",

--- a/src/Fieldset.php
+++ b/src/Fieldset.php
@@ -412,10 +412,30 @@ class Fieldset extends Element implements FieldsetInterface
                 }
             }
 
-            if ($valueExists) {
+            if ($valueExists
+                || (is_array($data) && array_key_exists($name, $data))
+                || ($data instanceof Traversable && $this->propertyExists($data, $name))
+            ) {
                 $elementOrFieldset->setValue($data[$name]);
             }
         }
+    }
+
+    /**
+     * Compatibility function to work with any Traversable.
+     *
+     * @see https://bugs.php.net/bug.php?id=79384
+     *
+     * @param string $name
+     * @return bool
+     */
+    private function propertyExists(Traversable $object, $name)
+    {
+        if (property_exists($object, $name)) {
+            return true;
+        }
+
+        return array_key_exists($name, iterator_to_array($object));
     }
 
     /**

--- a/src/Fieldset.php
+++ b/src/Fieldset.php
@@ -391,7 +391,7 @@ class Fieldset extends Element implements FieldsetInterface
         }
 
         foreach ($this->iterator as $name => $elementOrFieldset) {
-            $valueExists = array_key_exists($name, $data);
+            $valueExists = isset($data[$name]);
 
             if ($elementOrFieldset instanceof FieldsetInterface) {
                 if ($valueExists && (is_array($data[$name]) || $data[$name] instanceof Traversable)) {

--- a/src/Fieldset.php
+++ b/src/Fieldset.php
@@ -13,6 +13,7 @@ use Laminas\Form\Element\Collection;
 use Laminas\Hydrator;
 use Laminas\Hydrator\HydratorAwareInterface;
 use Laminas\Hydrator\HydratorInterface;
+use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\PriorityList;
 use Traversable;
 
@@ -383,10 +384,8 @@ class Fieldset extends Element implements FieldsetInterface
     public function populateValues($data)
     {
         if ($data instanceof Traversable) {
-            $data = iterator_to_array($data);
-        }
-
-        if (! is_array($data)) {
+            $data = ArrayUtils::iteratorToArray($data);
+        } elseif (! is_array($data)) {
             throw new Exception\InvalidArgumentException(sprintf(
                 '%s expects an array or Traversable set of data; received "%s"',
                 __METHOD__,

--- a/src/Fieldset.php
+++ b/src/Fieldset.php
@@ -382,16 +382,20 @@ class Fieldset extends Element implements FieldsetInterface
      */
     public function populateValues($data)
     {
-        if (! is_array($data) && ! $data instanceof Traversable) {
+        if ($data instanceof Traversable) {
+            $data = iterator_to_array($data);
+        }
+
+        if (! is_array($data)) {
             throw new Exception\InvalidArgumentException(sprintf(
                 '%s expects an array or Traversable set of data; received "%s"',
                 __METHOD__,
-                (is_object($data) ? get_class($data) : gettype($data))
+                is_object($data) ? get_class($data) : gettype($data)
             ));
         }
 
         foreach ($this->iterator as $name => $elementOrFieldset) {
-            $valueExists = isset($data[$name]);
+            $valueExists = array_key_exists($name, $data);
 
             if ($elementOrFieldset instanceof FieldsetInterface) {
                 if ($valueExists && (is_array($data[$name]) || $data[$name] instanceof Traversable)) {
@@ -412,30 +416,10 @@ class Fieldset extends Element implements FieldsetInterface
                 }
             }
 
-            if ($valueExists
-                || (is_array($data) && array_key_exists($name, $data))
-                || ($data instanceof Traversable && $this->propertyExists($data, $name))
-            ) {
+            if ($valueExists) {
                 $elementOrFieldset->setValue($data[$name]);
             }
         }
-    }
-
-    /**
-     * Compatibility function to work with any Traversable.
-     *
-     * @see https://bugs.php.net/bug.php?id=79384
-     *
-     * @param string $name
-     * @return bool
-     */
-    private function propertyExists(Traversable $object, $name)
-    {
-        if (property_exists($object, $name)) {
-            return true;
-        }
-
-        return array_key_exists($name, iterator_to_array($object));
     }
 
     /**

--- a/test/FieldsetTest.php
+++ b/test/FieldsetTest.php
@@ -8,7 +8,6 @@
 
 namespace LaminasTest\Form;
 
-use ArrayObject;
 use Laminas\Form\Element;
 use Laminas\Form\Fieldset;
 use Laminas\Form\Form;
@@ -629,10 +628,10 @@ class FieldsetTest extends TestCase
         $subValue = 'sub-element-value';
         $subElement = new Element('subElement');
         $this->fieldset->add($subElement);
-        $this->fieldset->populateValues(new ArrayObject(['subElement' => $subValue]));
+        $this->fieldset->populateValues(new TestAsset\CustomTraversable(['subElement' => $subValue]));
         $this->assertSame($subValue, $subElement->getValue());
 
-        $this->fieldset->populateValues(new ArrayObject(['subElement' => null]));
+        $this->fieldset->populateValues(new TestAsset\CustomTraversable(['subElement' => null]));
         $this->assertNull($subElement->getValue());
     }
 }

--- a/test/FieldsetTest.php
+++ b/test/FieldsetTest.php
@@ -8,6 +8,7 @@
 
 namespace LaminasTest\Form;
 
+use ArrayObject;
 use Laminas\Form\Element;
 use Laminas\Form\Fieldset;
 use Laminas\Form\Form;
@@ -17,6 +18,9 @@ use PHPUnit\Framework\TestCase;
 
 class FieldsetTest extends TestCase
 {
+    /** @var Fieldset */
+    private $fieldset;
+
     public function setUp()
     {
         $this->fieldset = new Fieldset();
@@ -606,5 +610,29 @@ class FieldsetTest extends TestCase
         $fieldset->setMessages($messages);
 
         $this->assertEquals($messages, $fieldset->getMessages());
+    }
+
+    public function testSetNullValueWhenArrayProvided()
+    {
+        $subValue = 'sub-element-value';
+        $subElement = new Element('subElement');
+        $this->fieldset->add($subElement);
+        $this->fieldset->populateValues(['subElement' => $subValue]);
+        $this->assertSame($subValue, $subElement->getValue());
+
+        $this->fieldset->populateValues(['subElement' => null]);
+        $this->assertNull($subElement->getValue());
+    }
+
+    public function testSetNullValueWhenTraversableProvided()
+    {
+        $subValue = 'sub-element-value';
+        $subElement = new Element('subElement');
+        $this->fieldset->add($subElement);
+        $this->fieldset->populateValues(new ArrayObject(['subElement' => $subValue]));
+        $this->assertSame($subValue, $subElement->getValue());
+
+        $this->fieldset->populateValues(new ArrayObject(['subElement' => null]));
+        $this->assertNull($subElement->getValue());
     }
 }

--- a/test/TestAsset/CustomTraversable.php
+++ b/test/TestAsset/CustomTraversable.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace LaminasTest\Form\TestAsset;
+
+use Iterator;
+
+class CustomTraversable implements Iterator
+{
+    /** @var array */
+    private $data;
+
+    public function __construct(array $data)
+    {
+        $this->data = $data;
+    }
+
+    public function current()
+    {
+        return current($this->data);
+    }
+
+    public function next()
+    {
+        return next($this->data);
+    }
+
+    public function key()
+    {
+        return key($this->data);
+    }
+
+    public function valid()
+    {
+        return $this->key() !== null;
+    }
+
+    public function rewind()
+    {
+        return reset($this->data);
+    }
+}


### PR DESCRIPTION
```

1) LaminasTest\Form\FieldsetTest::testExtractOnAnEmptyTraversable
array_key_exists(): Using array_key_exists() on objects is deprecated. Use isset() or property_exists() instead

/work/GIT/laminas/laminas-form/src/Fieldset.php:394
/work/GIT/laminas/laminas-form/src/Form.php:952
/work/GIT/laminas/laminas-form/test/FieldsetTest.php:95

ERRORS!
Tests: 2084, Assertions: 3230, Errors: 1, Skipped: 41.

```

Also switch to phpunit v7 as v6 doesn't work properly with 7.4