### PR TITLE
Fixes usage Traversable objects

### DIFF
--- a/src/Element.php
+++ b/src/Element.php
@@ -56,8 +56,8 @@ class Element implements
     protected $value;
 
     /**
-     * @param  null|int|string  $name    Optional name for the element
-     * @param  array            $options Optional options for the element
+     * @param  null|int|string   $name    Optional name for the element
+     * @param  array|Traversable $options Optional options for the element
      * @throws Exception\InvalidArgumentException
      */
     public function __construct($name = null, $options = [])

--- a/src/Element.php
+++ b/src/Element.php
@@ -41,7 +41,7 @@ class Element implements
     protected $labelOptions = [];
 
     /**
-     * @var array Validation error messages
+     * @var array|Traversable Validation error messages
      */
     protected $messages = [];
 

--- a/src/Element/Checkbox.php
+++ b/src/Element/Checkbox.php
@@ -57,16 +57,16 @@ class Checkbox extends Element implements InputProviderInterface
     {
         parent::setOptions($options);
 
-        if (isset($options['use_hidden_element'])) {
-            $this->setUseHiddenElement($options['use_hidden_element']);
+        if (isset($this->options['use_hidden_element'])) {
+            $this->setUseHiddenElement($this->options['use_hidden_element']);
         }
 
-        if (isset($options['unchecked_value'])) {
-            $this->setUncheckedValue($options['unchecked_value']);
+        if (isset($this->options['unchecked_value'])) {
+            $this->setUncheckedValue($this->options['unchecked_value']);
         }
 
-        if (isset($options['checked_value'])) {
-            $this->setCheckedValue($options['checked_value']);
+        if (isset($this->options['checked_value'])) {
+            $this->setCheckedValue($this->options['checked_value']);
         }
 
         return $this;

--- a/src/Element/Collection.php
+++ b/src/Element/Collection.php
@@ -509,9 +509,7 @@ class Collection extends Fieldset
     {
         if ($this->object instanceof Traversable) {
             $this->object = ArrayUtils::iteratorToArray($this->object, false);
-        }
-
-        if (! is_array($this->object)) {
+        } elseif (! is_array($this->object)) {
             return [];
         }
 

--- a/src/Element/Collection.php
+++ b/src/Element/Collection.php
@@ -8,7 +8,6 @@
 
 namespace Laminas\Form\Element;
 
-use Laminas\Form\Element;
 use Laminas\Form\ElementInterface;
 use Laminas\Form\Exception;
 use Laminas\Form\Fieldset;
@@ -162,11 +161,13 @@ class Collection extends Fieldset
      */
     public function setObject($object)
     {
-        if (! is_array($object) && ! $object instanceof Traversable) {
+        if ($object instanceof Traversable) {
+            $object = iterator_to_array($object);
+        } elseif (! is_array($object)) {
             throw new Exception\InvalidArgumentException(sprintf(
                 '%s expects an array or Traversable object argument; received "%s"',
                 __METHOD__,
-                (is_object($object) ? get_class($object) : gettype($object))
+                is_object($object) ? get_class($object) : gettype($object)
             ));
         }
 
@@ -186,11 +187,13 @@ class Collection extends Fieldset
      */
     public function populateValues($data)
     {
-        if (! is_array($data) && ! $data instanceof Traversable) {
+        if ($data instanceof Traversable) {
+            $data = ArrayUtils::iteratorToArray($data);
+        } elseif (! is_array($data)) {
             throw new Exception\InvalidArgumentException(sprintf(
                 '%s expects an array or Traversable set of data; received "%s"',
                 __METHOD__,
-                (is_object($data) ? get_class($data) : gettype($data))
+                is_object($data) ? get_class($data) : gettype($data)
             ));
         }
 

--- a/src/Element/Collection.php
+++ b/src/Element/Collection.php
@@ -110,32 +110,32 @@ class Collection extends Fieldset
     {
         parent::setOptions($options);
 
-        if (isset($options['target_element'])) {
-            $this->setTargetElement($options['target_element']);
+        if (isset($this->options['target_element'])) {
+            $this->setTargetElement($this->options['target_element']);
         }
 
-        if (isset($options['count'])) {
-            $this->setCount($options['count']);
+        if (isset($this->options['count'])) {
+            $this->setCount($this->options['count']);
         }
 
-        if (isset($options['allow_add'])) {
-            $this->setAllowAdd($options['allow_add']);
+        if (isset($this->options['allow_add'])) {
+            $this->setAllowAdd($this->options['allow_add']);
         }
 
-        if (isset($options['allow_remove'])) {
-            $this->setAllowRemove($options['allow_remove']);
+        if (isset($this->options['allow_remove'])) {
+            $this->setAllowRemove($this->options['allow_remove']);
         }
 
-        if (isset($options['should_create_template'])) {
-            $this->setShouldCreateTemplate($options['should_create_template']);
+        if (isset($this->options['should_create_template'])) {
+            $this->setShouldCreateTemplate($this->options['should_create_template']);
         }
 
-        if (isset($options['template_placeholder'])) {
-            $this->setTemplatePlaceholder($options['template_placeholder']);
+        if (isset($this->options['template_placeholder'])) {
+            $this->setTemplatePlaceholder($this->options['template_placeholder']);
         }
 
-        if (isset($options['create_new_objects'])) {
-            $this->setCreateNewObjects($options['create_new_objects']);
+        if (isset($this->options['create_new_objects'])) {
+            $this->setCreateNewObjects($this->options['create_new_objects']);
         }
 
         return $this;

--- a/src/Element/Csrf.php
+++ b/src/Element/Csrf.php
@@ -46,8 +46,8 @@ class Csrf extends Element implements InputProviderInterface, ElementPrepareAwar
     {
         parent::setOptions($options);
 
-        if (isset($options['csrf_options'])) {
-            $this->setCsrfValidatorOptions($options['csrf_options']);
+        if (isset($this->options['csrf_options'])) {
+            $this->setCsrfValidatorOptions($this->options['csrf_options']);
         }
 
         return $this;

--- a/src/Element/DateSelect.php
+++ b/src/Element/DateSelect.php
@@ -48,8 +48,8 @@ class DateSelect extends MonthSelect
     {
         parent::setOptions($options);
 
-        if (isset($options['day_attributes'])) {
-            $this->setDayAttributes($options['day_attributes']);
+        if (isset($this->options['day_attributes'])) {
+            $this->setDayAttributes($this->options['day_attributes']);
         }
 
         return $this;

--- a/src/Element/DateTimeSelect.php
+++ b/src/Element/DateTimeSelect.php
@@ -79,24 +79,20 @@ class DateTimeSelect extends DateSelect
     {
         parent::setOptions($options);
 
-        if ($options instanceof Traversable) {
-            $options = ArrayUtils::iteratorToArray($options);
+        if (isset($this->options['hour_attributes'])) {
+            $this->setHourAttributes($this->options['hour_attributes']);
         }
 
-        if (isset($options['hour_attributes'])) {
-            $this->setHourAttributes($options['hour_attributes']);
+        if (isset($this->options['minute_attributes'])) {
+            $this->setMinuteAttributes($this->options['minute_attributes']);
         }
 
-        if (isset($options['minute_attributes'])) {
-            $this->setMinuteAttributes($options['minute_attributes']);
+        if (isset($this->options['second_attributes'])) {
+            $this->setSecondAttributes($this->options['second_attributes']);
         }
 
-        if (isset($options['second_attributes'])) {
-            $this->setSecondAttributes($options['second_attributes']);
-        }
-
-        if (isset($options['should_show_seconds'])) {
-            $this->setShouldShowSeconds($options['should_show_seconds']);
+        if (isset($this->options['should_show_seconds'])) {
+            $this->setShouldShowSeconds($this->options['should_show_seconds']);
         }
 
         return $this;

--- a/src/Element/MonthSelect.php
+++ b/src/Element/MonthSelect.php
@@ -103,32 +103,28 @@ class MonthSelect extends Element implements InputProviderInterface, ElementPrep
     {
         parent::setOptions($options);
 
-        if ($options instanceof Traversable) {
-            $options = ArrayUtils::iteratorToArray($options);
+        if (isset($this->options['month_attributes'])) {
+            $this->setMonthAttributes($this->options['month_attributes']);
         }
 
-        if (isset($options['month_attributes'])) {
-            $this->setMonthAttributes($options['month_attributes']);
+        if (isset($this->options['year_attributes'])) {
+            $this->setYearAttributes($this->options['year_attributes']);
         }
 
-        if (isset($options['year_attributes'])) {
-            $this->setYearAttributes($options['year_attributes']);
+        if (isset($this->options['min_year'])) {
+            $this->setMinYear($this->options['min_year']);
         }
 
-        if (isset($options['min_year'])) {
-            $this->setMinYear($options['min_year']);
+        if (isset($this->options['max_year'])) {
+            $this->setMaxYear($this->options['max_year']);
         }
 
-        if (isset($options['max_year'])) {
-            $this->setMaxYear($options['max_year']);
+        if (isset($this->options['create_empty_option'])) {
+            $this->setShouldCreateEmptyOption($this->options['create_empty_option']);
         }
 
-        if (isset($options['create_empty_option'])) {
-            $this->setShouldCreateEmptyOption($options['create_empty_option']);
-        }
-
-        if (isset($options['render_delimiters'])) {
-            $this->setShouldRenderDelimiters($options['render_delimiters']);
+        if (isset($this->options['render_delimiters'])) {
+            $this->setShouldRenderDelimiters($this->options['render_delimiters']);
         }
 
         return $this;

--- a/src/Element/Select.php
+++ b/src/Element/Select.php
@@ -137,12 +137,12 @@ class Select extends Element implements InputProviderInterface
             $this->setDisableInArrayValidator($this->options['disable_inarray_validator']);
         }
 
-        if (isset($options['use_hidden_element'])) {
-            $this->setUseHiddenElement($options['use_hidden_element']);
+        if (isset($this->options['use_hidden_element'])) {
+            $this->setUseHiddenElement($this->options['use_hidden_element']);
         }
 
-        if (isset($options['unselected_value'])) {
-            $this->setUnselectedValue($options['unselected_value']);
+        if (isset($this->options['unselected_value'])) {
+            $this->setUnselectedValue($this->options['unselected_value']);
         }
 
         return $this;

--- a/src/ElementFactory.php
+++ b/src/ElementFactory.php
@@ -39,9 +39,7 @@ final class ElementFactory implements FactoryInterface
 
         if ($creationOptions instanceof Traversable) {
             $creationOptions = iterator_to_array($creationOptions);
-        }
-
-        if (! is_array($creationOptions)) {
+        } elseif (! is_array($creationOptions)) {
             throw new InvalidServiceException(sprintf(
                 '%s cannot use non-array, non-traversable, non-null creation options; received %s',
                 __CLASS__,

--- a/src/Fieldset.php
+++ b/src/Fieldset.php
@@ -95,12 +95,12 @@ class Fieldset extends Element implements FieldsetInterface
     {
         parent::setOptions($options);
 
-        if (isset($options['use_as_base_fieldset'])) {
-            $this->setUseAsBaseFieldset($options['use_as_base_fieldset']);
+        if (isset($this->options['use_as_base_fieldset'])) {
+            $this->setUseAsBaseFieldset($this->options['use_as_base_fieldset']);
         }
 
-        if (isset($options['allowed_object_binding_class'])) {
-            $this->setAllowedObjectBindingClass($options['allowed_object_binding_class']);
+        if (isset($this->options['allowed_object_binding_class'])) {
+            $this->setAllowedObjectBindingClass($this->options['allowed_object_binding_class']);
         }
 
         return $this;

--- a/src/Fieldset.php
+++ b/src/Fieldset.php
@@ -331,9 +331,9 @@ class Fieldset extends Element implements FieldsetInterface
             $messages = $this->messages;
             foreach ($this->iterator as $name => $element) {
                 $messageSet = $element->getMessages();
-                if (! is_array($messageSet)
-                    && ! $messageSet instanceof Traversable
-                    || empty($messageSet)) {
+                if (empty($messageSet)
+                    || (! is_array($messageSet) && ! $messageSet instanceof Traversable)
+                ) {
                     continue;
                 }
                 $messages[$name] = $messageSet;

--- a/src/Form.php
+++ b/src/Form.php
@@ -254,8 +254,7 @@ class Form extends Fieldset implements FormInterface
     {
         if ($data instanceof Traversable) {
             $data = ArrayUtils::iteratorToArray($data);
-        }
-        if (! is_array($data)) {
+        } elseif (! is_array($data)) {
             throw new Exception\InvalidArgumentException(sprintf(
                 '%s expects an array or Traversable argument; received "%s"',
                 __METHOD__,

--- a/src/View/Helper/FormElementErrors.php
+++ b/src/View/Helper/FormElementErrors.php
@@ -69,8 +69,9 @@ class FormElementErrors extends AbstractHelper
             return '';
         }
 
-        $messages = $messages instanceof Traversable ? iterator_to_array($messages) : $messages;
-        if (! is_array($messages)) {
+        if ($messages instanceof Traversable) {
+            $messages = iterator_to_array($messages);
+        } elseif (! is_array($messages)) {
             throw new Exception\DomainException(sprintf(
                 '%s expects that $element->getMessages() will return an array or Traversable; received "%s"',
                 __METHOD__,

--- a/src/View/Helper/FormElementErrors.php
+++ b/src/View/Helper/FormElementErrors.php
@@ -65,10 +65,6 @@ class FormElementErrors extends AbstractHelper
     public function render(ElementInterface $element, array $attributes = [])
     {
         $messages = $element->getMessages();
-        if (empty($messages)) {
-            return '';
-        }
-
         if ($messages instanceof Traversable) {
             $messages = iterator_to_array($messages);
         } elseif (! is_array($messages)) {
@@ -79,9 +75,13 @@ class FormElementErrors extends AbstractHelper
             ));
         }
 
+        if (! $messages) {
+            return '';
+        }
+
         // Flatten message array
         $messages = $this->flattenMessages($messages);
-        if (empty($messages)) {
+        if (! $messages) {
             return '';
         }
 

--- a/test/Element/CheckboxTest.php
+++ b/test/Element/CheckboxTest.php
@@ -9,6 +9,7 @@
 namespace LaminasTest\Form\Element;
 
 use Laminas\Form\Element\Checkbox as CheckboxElement;
+use LaminasTest\Form\TestAsset\CustomTraversable;
 use PHPUnit\Framework\TestCase;
 
 class CheckboxTest extends TestCase
@@ -114,10 +115,23 @@ class CheckboxTest extends TestCase
     {
         $element = new CheckboxElement();
         $element->setOptions([
-                                  'use_hidden_element' => true,
-                                  'unchecked_value' => 'foo',
-                                  'checked_value' => 'bar',
-                             ]);
+            'use_hidden_element' => true,
+            'unchecked_value' => 'foo',
+            'checked_value' => 'bar',
+        ]);
+        $this->assertEquals(true, $element->getOption('use_hidden_element'));
+        $this->assertEquals('foo', $element->getOption('unchecked_value'));
+        $this->assertEquals('bar', $element->getOption('checked_value'));
+    }
+
+    public function testSetOptionsTraversable()
+    {
+        $element = new CheckboxElement();
+        $element->setOptions(new CustomTraversable([
+            'use_hidden_element' => true,
+            'unchecked_value' => 'foo',
+            'checked_value' => 'bar',
+        ]));
         $this->assertEquals(true, $element->getOption('use_hidden_element'));
         $this->assertEquals('foo', $element->getOption('unchecked_value'));
         $this->assertEquals('bar', $element->getOption('checked_value'));

--- a/test/Element/CollectionTest.php
+++ b/test/Element/CollectionTest.php
@@ -23,6 +23,7 @@ use Laminas\InputFilter\ArrayInput;
 use LaminasTest\Form\TestAsset\AddressFieldset;
 use LaminasTest\Form\TestAsset\ArrayModel;
 use LaminasTest\Form\TestAsset\CustomCollection;
+use LaminasTest\Form\TestAsset\CustomTraversable;
 use LaminasTest\Form\TestAsset\Entity\Address;
 use LaminasTest\Form\TestAsset\Entity\Phone;
 use LaminasTest\Form\TestAsset\Entity\Product;
@@ -315,6 +316,28 @@ class CollectionTest extends TestCase
             'should_create_template' => true,
             'template_placeholder' => 'foo',
         ]);
+
+        $this->assertInstanceOf('Laminas\Form\Element', $collection->getOption('target_element'));
+        $this->assertEquals(2, $collection->getOption('count'));
+        $this->assertEquals(true, $collection->getOption('allow_add'));
+        $this->assertEquals(false, $collection->getOption('allow_remove'));
+        $this->assertEquals(true, $collection->getOption('should_create_template'));
+        $this->assertEquals('foo', $collection->getOption('template_placeholder'));
+    }
+
+    public function testSetOptionsTraversable()
+    {
+        $collection = $this->form->get('colors');
+        $element = new Element('foo');
+        $collection->setOptions(new CustomTraversable([
+            'target_element' => $element,
+            'count' => 2,
+            'allow_add' => true,
+            'allow_remove' => false,
+            'should_create_template' => true,
+            'template_placeholder' => 'foo',
+        ]));
+
         $this->assertInstanceOf('Laminas\Form\Element', $collection->getOption('target_element'));
         $this->assertEquals(2, $collection->getOption('count'));
         $this->assertEquals(true, $collection->getOption('allow_add'));

--- a/test/Element/CollectionTest.php
+++ b/test/Element/CollectionTest.php
@@ -1458,4 +1458,45 @@ class CollectionTest extends TestCase
             $form->getData()
         );
     }
+
+    public function testPopulateValuesTraversable()
+    {
+        $data = new CustomTraversable(['blue', 'green']);
+
+        $collection = $this->form->get('colors');
+        $collection->setAllowRemove(false);
+        $collection->populateValues($data);
+
+        $this->assertCount(2, $collection->getElements());
+    }
+
+    public function testSetObjectTraversable()
+    {
+        $collection = $this->form->get('fieldsets');
+
+        // this test is using a hydrator set on the target element of the collection
+        $targetElement = $collection->getTargetElement();
+        $targetElement->setHydrator(
+            class_exists(ArraySerializableHydrator::class)
+                ? new ArraySerializableHydrator()
+                : new ArraySerializable()
+        );
+        $obj1 = new ArrayModel();
+        $targetElement->setObject($obj1);
+
+        $obj2 = new ArrayModel();
+        $obj2->exchangeArray(['foo' => 'foo_value_1', 'bar' => 'bar_value_1', 'foobar' => 'foobar_value_1']);
+        $obj3 = new ArrayModel();
+        $obj3->exchangeArray(['foo' => 'foo_value_2', 'bar' => 'bar_value_2', 'foobar' => 'foobar_value_2']);
+
+        $collection->setObject(new CustomTraversable([$obj2, $obj3]));
+
+        $expected = [
+            ['foo' => 'foo_value_1', 'bar' => 'bar_value_1', 'foobar' => 'foobar_value_1'],
+            ['foo' => 'foo_value_2', 'bar' => 'bar_value_2', 'foobar' => 'foobar_value_2'],
+        ];
+
+        $this->assertSame($expected, $collection->extract());
+        $this->assertSame([$obj2, $obj3], $collection->getObject());
+    }
 }

--- a/test/Element/CsrfTest.php
+++ b/test/Element/CsrfTest.php
@@ -9,6 +9,7 @@
 namespace LaminasTest\Form\Element;
 
 use Laminas\Form\Element\Csrf as CsrfElement;
+use LaminasTest\Form\TestAsset\CustomTraversable;
 use PHPUnit\Framework\TestCase;
 
 class CsrfTest extends TestCase
@@ -60,8 +61,24 @@ class CsrfTest extends TestCase
         $element->setOptions([
             'csrf_options' => [
                 'timeout' => 777,
-                'salt' => 'MySalt']
-            ]);
+                'salt' => 'MySalt',
+            ],
+        ]);
+        $validator = $element->getCsrfValidator();
+        $this->assertEquals('foo', $validator->getName());
+        $this->assertEquals(777, $validator->getTimeOut());
+        $this->assertEquals('MySalt', $validator->getSalt());
+    }
+
+    public function testSetOptionsTraversable()
+    {
+        $element = new CsrfElement('foo');
+        $element->setOptions(new CustomTraversable([
+            'csrf_options' => [
+                'timeout' => 777,
+                'salt' => 'MySalt',
+            ],
+        ]));
         $validator = $element->getCsrfValidator();
         $this->assertEquals('foo', $validator->getName());
         $this->assertEquals(777, $validator->getTimeOut());

--- a/test/Element/DateSelectTest.php
+++ b/test/Element/DateSelectTest.php
@@ -10,6 +10,7 @@ namespace LaminasTest\Form\Element;
 
 use DateTime;
 use Laminas\Form\Element\DateSelect as DateSelectElement;
+use LaminasTest\Form\TestAsset\CustomTraversable;
 use PHPUnit\Framework\TestCase;
 
 class DateSelectTest extends TestCase
@@ -80,6 +81,27 @@ class DateSelectTest extends TestCase
         $sut = new DateSelectElement('dateSelect', ['day_attributes' => ['class' => 'test']]);
         $dayAttributes = $sut->getDayAttributes();
         $this->assertEquals('test', $dayAttributes['class']);
+    }
+
+    public function testConstructAcceptsTraversableOptions()
+    {
+        $options = new CustomTraversable([
+            'day_attributes' => ['class' => 'test'],
+        ]);
+        $sut = new DateSelectElement('dateSelect', $options);
+
+        $this->assertSame('test', $sut->getDayAttributes()['class']);
+    }
+
+    public function testSetOptionsAcceptsTraversableObject()
+    {
+        $options = new CustomTraversable([
+            'day_attributes' => ['class' => 'test'],
+        ]);
+        $sut = new DateSelectElement();
+        $sut->setOptions($options);
+
+        $this->assertSame('test', $sut->getDayAttributes()['class']);
     }
 
     /**

--- a/test/Element/SelectTest.php
+++ b/test/Element/SelectTest.php
@@ -9,6 +9,7 @@
 namespace LaminasTest\Form\Element;
 
 use Laminas\Form\Element\Select as SelectElement;
+use LaminasTest\Form\TestAsset\CustomTraversable;
 use PHPUnit\Framework\TestCase;
 
 class SelectTest extends TestCase
@@ -179,14 +180,27 @@ class SelectTest extends TestCase
         $this->assertEquals($valueOptions, $element->getValueOptions());
     }
 
-    public function testSetOptionsOptions()
+    public function testSetOptionsArray()
     {
         $element = new SelectElement();
         $element->setOptions([
-                                  'value_options' => ['bar' => 'baz'],
-                                  'options' => ['foo' => 'bar'],
-                                  'empty_option' => ['baz' => 'foo'],
-                             ]);
+            'value_options' => ['bar' => 'baz'],
+            'options' => ['foo' => 'bar'],
+            'empty_option' => ['baz' => 'foo'],
+        ]);
+        $this->assertEquals(['bar' => 'baz'], $element->getOption('value_options'));
+        $this->assertEquals(['foo' => 'bar'], $element->getOption('options'));
+        $this->assertEquals(['baz' => 'foo'], $element->getOption('empty_option'));
+    }
+
+    public function testSetOptionsTraversable()
+    {
+        $element = new SelectElement();
+        $element->setOptions(new CustomTraversable([
+            'value_options' => ['bar' => 'baz'],
+            'options' => ['foo' => 'bar'],
+            'empty_option' => ['baz' => 'foo'],
+        ]));
         $this->assertEquals(['bar' => 'baz'], $element->getOption('value_options'));
         $this->assertEquals(['foo' => 'bar'], $element->getOption('options'));
         $this->assertEquals(['baz' => 'foo'], $element->getOption('empty_option'));

--- a/test/LabelAwareTraitTest.php
+++ b/test/LabelAwareTraitTest.php
@@ -7,6 +7,7 @@
  */
 namespace LaminasTest\Form;
 
+use LaminasTest\Form\TestAsset\CustomTraversable;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -77,6 +78,22 @@ class LabelAwareTraitTest extends TestCase
         ];
 
         $object->setLabelOptions($labelOptions);
+
+        $retrievedLabelOptions = $object->getLabelOptions();
+
+        $this->assertEquals($retrievedLabelOptions, $labelOptions);
+    }
+
+    public function testSetLabelOptionsTraversable()
+    {
+        $object = $this->getObjectForTrait('\Laminas\Form\LabelAwareTrait');
+
+        $labelOptions = [
+            'foo' => 'bar',
+            'foo2' => 'bar2',
+        ];
+
+        $object->setLabelOptions(new CustomTraversable($labelOptions));
 
         $retrievedLabelOptions = $object->getLabelOptions();
 


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.
Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch
-->

|    Q          |   A
|-------------- | ------
| Bugfix        | yes

### Description

In many places we suppose to accept any Traversable object but unfortunately it was not working correctly. I've added test cases to cover changes and fixes all places I've found. These are mainly:
- several Elements and method `setOptions`
- Collection element - `setObject` and `populateValues`

In couple other places converted if statement to else-if - after we convert Traversable to an array there is no point to check again if the variable is an array.

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
