### PR TITLE
Allow autocomplete attribute for hidden fields

### DIFF
--- a/src/View/Helper/FormHidden.php
+++ b/src/View/Helper/FormHidden.php
@@ -23,6 +23,7 @@ class FormHidden extends FormInput
         'form'           => true,
         'type'           => true,
         'value'          => true,
+        'autocomplete'   => true,
     ];
 
     /**

--- a/test/View/Helper/FormHiddenTest.php
+++ b/test/View/Helper/FormHiddenTest.php
@@ -52,7 +52,7 @@ class FormHiddenTest extends CommonTestCase
             ['name', 'assertContains'],
             ['accept', 'assertNotContains'],
             ['alt', 'assertNotContains'],
-            ['autocomplete', 'assertNotContains'],
+            ['autocomplete', 'assertContains'],
             ['autofocus', 'assertNotContains'],
             ['checked', 'assertNotContains'],
             ['dirname', 'assertNotContains'],


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

We have an application that uses JS-triggered page reloads to refresh data. We noticed that in Firefox 77.0.1 values in hidden fields were not updating. 
- Tests with Chrome 83 and FF 75 were successfull -> hidden field values are updating correctly. 
- Manually reloading the page with F5, Strg-R or Command-R shows the bad behaviour. 
- Using a page reload without cache (e. g. Strg-Shift-R) fixes the error.

In order to fix this we need to set "autocomplete=off" to all hidden fields in order to deny Firefox the autocompletion. 
This PR adds the ability to use the "autocomplete" attribute on a hidden field (validated by the FormHidden View Helper).

Bug-Report: https://bugzilla.mozilla.org/show_bug.cgi?id=520561
