### PR TITLE
Added 2 tests for the DateSelect element around null value semantics

### DIFF
--- a/test/Element/DateSelectTest.php
+++ b/test/Element/DateSelectTest.php
@@ -115,4 +115,24 @@ class DateSelectTest extends TestCase
 
         $this->assertSame($element, $element->setValue('2014-01-01'));
     }
+    
+    public function testNullSetValueIsSemanticallyTodayWithoutEmptyOption()
+    {
+        $element  = new DateSelectElement('foo');
+        $element->setShouldCreateEmptyOption(false);
+        $now = new \DateTime();
+        $element->setValue(null);
+        $value = $element->getValue();
+        // the getValue() function returns the date in 'Y-m-d' format
+        $this->assertEquals($now->format('Y-m-d'), $value);
+    }
+    
+    public function testNullSetValueIsNullWithEmptyOption()
+    {
+        $element  = new DateSelectElement('foo');
+        $element->setShouldCreateEmptyOption(true);
+        $element->setValue(null);
+        $value = $element->getValue();
+        $this->assertEquals(null, $value);
+    }
 }


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | yes
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

<!--
Tell us about why this change is necessary:

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?

  Additional tests that don't change behavior. It wasn't clear what happens when a null is set to the DateSelect element. This creates tests that clarify this.
