### PR TITLE
fix Form::getInputFilter() phpdoc return type to match FormInterface

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -687,7 +687,7 @@ class Form extends Fieldset implements FormInterface
     /**
      * Retrieve input filter used by this form
      *
-     * @return null|InputFilterInterface
+     * @return InputFilterInterface
      */
     public function getInputFilter()
     {


### PR DESCRIPTION
https://github.com/laminas/laminas-form/blob/a028e927ed1b07a98e43c22d5e7cac796f7a0e9d/src/Form.php#L708 makes sure it is created.