### PR TITLE
fix: revert bc-break introduced in version 2.16.0

### DIFF
--- a/test/FormElementManagerTest.php
+++ b/test/FormElementManagerTest.php
@@ -15,6 +15,7 @@ use Laminas\Form\Form;
 use Laminas\Form\FormElementManager;
 use Laminas\ServiceManager\Exception\InvalidServiceException;
 use Laminas\ServiceManager\ServiceManager;
+use LaminasTest\Form\TestAsset\InvokableForm;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 
@@ -241,5 +242,17 @@ class FormElementManagerTest extends TestCase
         }
 
         $this->addToAssertionCount(1);
+    }
+
+    public function testOptionsAreSetInInvokableForm(): void
+    {
+        $options = ['foo' => 'bar'];
+
+        /** @var InvokableForm $form */
+        $form = $this->manager->get(InvokableForm::class, $options);
+
+        self::assertInstanceOf(InvokableForm::class, $form);
+        self::assertSame('invokableform', $form->getName());
+        self::assertSame('bar', $form->getOption('foo'));
     }
 }

--- a/test/TestAsset/InvokableForm.php
+++ b/test/TestAsset/InvokableForm.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Form\TestAsset;
+
+use Laminas\Form\Form;
+
+final class InvokableForm extends Form
+{
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Re-adds `\Laminas\Form\FormElementManager\FormElementManagerTrait::get` method to `\Laminas\Form\FormElementManager` to restore previous behavior.

fixes #92 
