### PR TITLE
render boolean attributes without value for HTML5

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1664,12 +1664,13 @@
       <code>$this-&gt;booleanAttributes[$attribute]['on']</code>
       <code>$this-&gt;booleanAttributes[$key]['off']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="10">
+    <MixedAssignment occurrences="11">
       <code>$attributes[$attribute]</code>
       <code>$escapedAttribute</code>
       <code>$prefix</code>
       <code>$prefix</code>
       <code>$prefix</code>
+      <code>$strings[]</code>
       <code>$this-&gt;doctypeHelper</code>
       <code>$this-&gt;escapeHtmlAttrHelper</code>
       <code>$this-&gt;escapeHtmlHelper</code>
@@ -7032,22 +7033,26 @@
       <code>$mockTranslator</code>
       <code>$mockTranslator</code>
     </InvalidArgument>
-    <MissingParamType occurrences="9">
+    <MissingParamType occurrences="12">
       <code>$assertion</code>
       <code>$assertion</code>
+      <code>$attribute</code>
       <code>$attribute</code>
       <code>$attribute</code>
       <code>$doctype</code>
       <code>$doctype</code>
       <code>$off</code>
+      <code>$off</code>
+      <code>$on</code>
       <code>$on</code>
       <code>$type</code>
     </MissingParamType>
-    <MissingReturnType occurrences="17">
+    <MissingReturnType occurrences="18">
       <code>getCompleteElement</code>
       <code>inputTypes</code>
       <code>nonXhtmlDoctypes</code>
       <code>testBooleanAttributeTypesAreRenderedCorrectly</code>
+      <code>testBooleanAttributeTypesAreRenderedCorrectlyWithoutValueForHtml5</code>
       <code>testCanTranslatePlaceholder</code>
       <code>testCanTranslateTitle</code>
       <code>testGeneratesInputTagWithElementsTypeAttribute</code>
@@ -7062,7 +7067,23 @@
       <code>validAttributes2</code>
       <code>xhtmlDoctypes</code>
     </MissingReturnType>
-    <MixedArgument occurrences="47">
+    <MixedArgument occurrences="89">
+      <code>$attribute</code>
+      <code>$attribute</code>
+      <code>$attribute</code>
+      <code>$attribute</code>
+      <code>$attribute</code>
+      <code>$attribute</code>
+      <code>$attribute</code>
+      <code>$attribute</code>
+      <code>$attribute</code>
+      <code>$attribute</code>
+      <code>$attribute</code>
+      <code>$attribute</code>
+      <code>$attribute</code>
+      <code>$attribute</code>
+      <code>$attribute</code>
+      <code>$attribute</code>
       <code>$attribute</code>
       <code>$attribute</code>
       <code>$attribute</code>
@@ -7081,6 +7102,22 @@
       <code>$attribute</code>
       <code>$element-&gt;getAttribute($attribute)</code>
       <code>$element-&gt;getValue()</code>
+      <code>$expect</code>
+      <code>$expect</code>
+      <code>$expect</code>
+      <code>$expect</code>
+      <code>$markup</code>
+      <code>$markup</code>
+      <code>$markup</code>
+      <code>$markup</code>
+      <code>$markup</code>
+      <code>$markup</code>
+      <code>$markup</code>
+      <code>$markup</code>
+      <code>$markup</code>
+      <code>$markup</code>
+      <code>$markup</code>
+      <code>$markup</code>
       <code>$markup</code>
       <code>$markup</code>
       <code>$markup</code>
@@ -7105,14 +7142,32 @@
       <code>$off</code>
       <code>$off</code>
       <code>$off</code>
+      <code>$off</code>
+      <code>$off</code>
+      <code>$off</code>
+      <code>$off</code>
+      <code>$on</code>
+      <code>$on</code>
+      <code>$on</code>
+      <code>$on</code>
+      <code>$on</code>
+      <code>$on</code>
       <code>$on</code>
       <code>$on</code>
       <code>$on</code>
       <code>$on</code>
       <code>$type</code>
     </MixedArgument>
-    <MixedAssignment occurrences="15">
+    <MixedAssignment occurrences="23">
       <code>$element</code>
+      <code>$expect</code>
+      <code>$expect</code>
+      <code>$expect</code>
+      <code>$expect</code>
+      <code>$markup</code>
+      <code>$markup</code>
+      <code>$markup</code>
+      <code>$markup</code>
       <code>$markup</code>
       <code>$markup</code>
       <code>$markup</code>
@@ -7135,16 +7190,21 @@
       <code>getAttribute</code>
       <code>getValue</code>
     </MixedMethodCall>
-    <UndefinedInterfaceMethod occurrences="2">
+    <UndefinedInterfaceMethod occurrences="3">
+      <code>doctype</code>
       <code>doctype</code>
       <code>doctype</code>
     </UndefinedInterfaceMethod>
-    <UndefinedMethod occurrences="16">
+    <UndefinedMethod occurrences="20">
       <code>__invoke</code>
       <code>__invoke</code>
       <code>__invoke</code>
       <code>__invoke</code>
       <code>__invoke</code>
+      <code>render</code>
+      <code>render</code>
+      <code>render</code>
+      <code>render</code>
       <code>render</code>
       <code>render</code>
       <code>render</code>
@@ -8545,18 +8605,22 @@
     <ArgumentTypeCoercion occurrences="1">
       <code>'Laminas\Form\Exception\DomainException'</code>
     </ArgumentTypeCoercion>
-    <MissingParamType occurrences="5">
+    <MissingParamType occurrences="8">
       <code>$assertion</code>
       <code>$attribute</code>
       <code>$attribute</code>
+      <code>$attribute</code>
+      <code>$off</code>
       <code>$off</code>
       <code>$on</code>
+      <code>$on</code>
     </MissingParamType>
-    <MissingReturnType occurrences="10">
+    <MissingReturnType occurrences="11">
       <code>booleanAttributeTypes</code>
       <code>getCompleteElement</code>
       <code>testAllValidFormMarkupAttributesPresentInElementAreRendered</code>
       <code>testBooleanAttributeTypesAreRenderedCorrectly</code>
+      <code>testBooleanAttributeTypesAreRenderedCorrectlyWithoutValueForHtml5</code>
       <code>testGeneratesEmptyTextareaWhenNoValueAttributePresent</code>
       <code>testInvokeProxiesToRender</code>
       <code>testInvokeWithNoElementChainsHelper</code>
@@ -8564,7 +8628,30 @@
       <code>testRendersValueAttributeAsTextareaContent</code>
       <code>validAttributes</code>
     </MissingReturnType>
-    <MixedArgument occurrences="22">
+    <MixedArgument occurrences="81">
+      <code>$attribute</code>
+      <code>$attribute</code>
+      <code>$attribute</code>
+      <code>$attribute</code>
+      <code>$attribute</code>
+      <code>$attribute</code>
+      <code>$attribute</code>
+      <code>$attribute</code>
+      <code>$attribute</code>
+      <code>$attribute</code>
+      <code>$attribute</code>
+      <code>$attribute</code>
+      <code>$attribute</code>
+      <code>$attribute</code>
+      <code>$attribute</code>
+      <code>$attribute</code>
+      <code>$attribute</code>
+      <code>$attribute</code>
+      <code>$attribute</code>
+      <code>$attribute</code>
+      <code>$attribute</code>
+      <code>$attribute</code>
+      <code>$attribute</code>
       <code>$attribute</code>
       <code>$attribute</code>
       <code>$attribute</code>
@@ -8574,6 +8661,28 @@
       <code>$attribute</code>
       <code>$attribute</code>
       <code>$element-&gt;getAttribute($attribute)</code>
+      <code>$expect</code>
+      <code>$expect</code>
+      <code>$expect</code>
+      <code>$expect</code>
+      <code>$markup</code>
+      <code>$markup</code>
+      <code>$markup</code>
+      <code>$markup</code>
+      <code>$markup</code>
+      <code>$markup</code>
+      <code>$markup</code>
+      <code>$markup</code>
+      <code>$markup</code>
+      <code>$markup</code>
+      <code>$markup</code>
+      <code>$markup</code>
+      <code>$markup</code>
+      <code>$markup</code>
+      <code>$markup</code>
+      <code>$markup</code>
+      <code>$markup</code>
+      <code>$markup</code>
       <code>$markup</code>
       <code>$markup</code>
       <code>$markup</code>
@@ -8585,11 +8694,35 @@
       <code>$markup</code>
       <code>$off</code>
       <code>$off</code>
+      <code>$off</code>
+      <code>$off</code>
+      <code>$off</code>
+      <code>$off</code>
+      <code>$off</code>
+      <code>$off</code>
+      <code>$on</code>
+      <code>$on</code>
+      <code>$on</code>
+      <code>$on</code>
+      <code>$on</code>
+      <code>$on</code>
+      <code>$on</code>
+      <code>$on</code>
       <code>$on</code>
       <code>$on</code>
     </MixedArgument>
-    <MixedAssignment occurrences="7">
+    <MixedAssignment occurrences="17">
       <code>$element</code>
+      <code>$expect</code>
+      <code>$expect</code>
+      <code>$expect</code>
+      <code>$expect</code>
+      <code>$markup</code>
+      <code>$markup</code>
+      <code>$markup</code>
+      <code>$markup</code>
+      <code>$markup</code>
+      <code>$markup</code>
       <code>$markup</code>
       <code>$markup</code>
       <code>$markup</code>
@@ -8600,9 +8733,18 @@
     <MixedMethodCall occurrences="1">
       <code>getAttribute</code>
     </MixedMethodCall>
-    <UndefinedMethod occurrences="8">
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>doctype</code>
+    </UndefinedInterfaceMethod>
+    <UndefinedMethod occurrences="14">
       <code>__invoke</code>
       <code>__invoke</code>
+      <code>render</code>
+      <code>render</code>
+      <code>render</code>
+      <code>render</code>
+      <code>render</code>
+      <code>render</code>
       <code>render</code>
       <code>render</code>
       <code>render</code>

--- a/src/View/Helper/AbstractHelper.php
+++ b/src/View/Helper/AbstractHelper.php
@@ -246,20 +246,27 @@ abstract class AbstractHelper extends BaseAbstractHelper
      */
     public function createAttributesString(array $attributes)
     {
-        $attributes = $this->prepareAttributes($attributes);
-        $escape     = $this->getEscapeHtmlHelper();
-        $escapeAttr = $this->getEscapeHtmlAttrHelper();
-        $strings    = [];
+        $attributes    = $this->prepareAttributes($attributes);
+        $escape        = $this->getEscapeHtmlHelper();
+        $escapeAttr    = $this->getEscapeHtmlAttrHelper();
+        $doctypeHelper = $this->getDoctypeHelper();
+        $strings       = [];
 
         foreach ($attributes as $key => $value) {
             $key = strtolower($key);
 
-            if (! $value && isset($this->booleanAttributes[$key])) {
-                // Skip boolean attributes that expect empty string as false value
-                if ('' === $this->booleanAttributes[$key]['off']) {
+            if (isset($this->booleanAttributes[$key])) {
+                if (! $value) {
+                    // Skip boolean attributes that expect empty string as false value
+                    if ('' === $this->booleanAttributes[$key]['off']) {
+                        continue;
+                    }
+                } elseif ($doctypeHelper->isHtml5() && ! $doctypeHelper->isXhtml()) {
+                    $strings[] = $escape($key);
                     continue;
                 }
             }
+
 
             //check if attribute is translatable and translate it
             $value = $this->translateHtmlAttributeValue($key, $value);

--- a/test/View/Helper/FormInputTest.php
+++ b/test/View/Helper/FormInputTest.php
@@ -473,6 +473,90 @@ class FormInputTest extends CommonTestCase
         }
     }
 
+    /**
+     * @group Laminas-391
+     * @dataProvider booleanAttributeTypes
+     */
+    public function testBooleanAttributeTypesAreRenderedCorrectlyWithoutValueForHtml5($attribute, $on, $off)
+    {
+        $element = new Element('foo');
+        $this->renderer->doctype('HTML5');
+        $element->setAttribute($attribute, true);
+        $markup = $this->helper->render($element);
+        $expect = $attribute;
+        $this->assertStringContainsString(
+            $expect,
+            $markup,
+            sprintf("Enabled value for %s should be '%s'; received %s", $attribute, $on, $markup)
+        );
+
+        $expect = sprintf('%s="%s"', $attribute, $on);
+        $this->assertStringNotContainsString(
+            $expect,
+            $markup,
+            sprintf("Enabled value for %s should not be '%s'; received %s", $attribute, $on, $markup)
+        );
+
+        $element->setAttribute($attribute, false);
+        $markup = $this->helper->render($element);
+
+        if ($off !== '') {
+            $expect = sprintf('%s="%s"', $attribute, $off);
+
+            $this->assertStringContainsString(
+                $expect,
+                $markup,
+                sprintf("Disabled value for %s should be '%s'; received %s", $attribute, $off, $markup)
+            );
+        } else {
+            $expect = $attribute;
+
+            $this->assertStringNotContainsString(
+                $expect,
+                $markup,
+                sprintf('Disabled value for %s should not be rendered; received %s', $attribute, $markup)
+            );
+        }
+
+        // Laminas-391 : Ability to use non-boolean values that match expected end-value
+        $element->setAttribute($attribute, $on);
+        $markup = $this->helper->render($element);
+        $expect = $attribute;
+        $this->assertStringContainsString(
+            $expect,
+            $markup,
+            sprintf("Enabled value for %s should be '%s'; received %s", $attribute, $on, $markup)
+        );
+
+        $expect = sprintf('%s="%s"', $attribute, $on);
+        $this->assertStringNotContainsString(
+            $expect,
+            $markup,
+            sprintf("Enabled value for %s should not be '%s'; received %s", $attribute, $on, $markup)
+        );
+
+        $element->setAttribute($attribute, $off);
+        $markup = $this->helper->render($element);
+
+        if ($off !== '') {
+            $expect = sprintf('%s="%s"', $attribute, $off);
+
+            $this->assertStringContainsString(
+                $expect,
+                $markup,
+                sprintf("Disabled value for %s should be '%s'; received %s", $attribute, $off, $markup)
+            );
+        } else {
+            $expect = $attribute;
+
+            $this->assertStringNotContainsString(
+                $expect,
+                $markup,
+                sprintf('Disabled value for %s should not be rendered; received %s', $attribute, $markup)
+            );
+        }
+    }
+
     public function testInvokeProxiesToRender()
     {
         $element = new Element('foo');

--- a/test/View/Helper/FormTextareaTest.php
+++ b/test/View/Helper/FormTextareaTest.php
@@ -285,6 +285,119 @@ class FormTextareaTest extends CommonTestCase
                 sprintf('Disabled value for %s should not be rendered; received %s', $attribute, $markup)
             );
         }
+
+        // Laminas-391 : Ability to use non-boolean values that match expected end-value
+        $element->setAttribute($attribute, $on);
+        $markup = $this->helper->render($element);
+        $expect = sprintf('%s="%s"', $attribute, $on);
+        $this->assertStringContainsString(
+            $expect,
+            $markup,
+            sprintf("Enabled value for %s should be '%s'; received %s", $attribute, $on, $markup)
+        );
+
+        $element->setAttribute($attribute, $off);
+        $markup = $this->helper->render($element);
+        $expect = sprintf('%s="%s"', $attribute, $off);
+
+        if ($off !== '') {
+            $this->assertStringContainsString(
+                $expect,
+                $markup,
+                sprintf("Disabled value for %s should be '%s'; received %s", $attribute, $off, $markup)
+            );
+        } else {
+            $this->assertStringNotContainsString(
+                $expect,
+                $markup,
+                sprintf('Disabled value for %s should not be rendered; received %s', $attribute, $markup)
+            );
+        }
+    }
+
+    /**
+     * @dataProvider booleanAttributeTypes
+     */
+    public function testBooleanAttributeTypesAreRenderedCorrectlyWithoutValueForHtml5($attribute, $on, $off)
+    {
+        $element = new Element('foo');
+        $this->renderer->doctype('HTML5');
+        $element->setAttribute($attribute, true);
+        $markup = $this->helper->render($element);
+        $expect = $attribute;
+
+        $this->assertStringContainsString(
+            $expect,
+            $markup,
+            sprintf("Enabled value for %s should be '%s'; received %s", $attribute, $on, $markup)
+        );
+
+        $expect = sprintf('%s="%s"', $attribute, $on);
+        $this->assertStringNotContainsString(
+            $expect,
+            $markup,
+            sprintf("Enabled value for %s should not be '%s'; received %s", $attribute, $on, $markup)
+        );
+
+        $element->setAttribute($attribute, false);
+        $markup = $this->helper->render($element);
+
+        if ($off !== '') {
+            $expect = sprintf('%s="%s"', $attribute, $off);
+
+            $this->assertStringContainsString(
+                $expect,
+                $markup,
+                sprintf("Disabled value for %s should be '%s'; received %s", $attribute, $off, $markup)
+            );
+        } else {
+            $expect = $attribute;
+
+            $this->assertStringNotContainsString(
+                $expect,
+                $markup,
+                sprintf('Disabled value for %s should not be rendered; received %s', $attribute, $markup)
+            );
+        }
+
+        // Laminas-391 : Ability to use non-boolean values that match expected end-value
+        $element->setAttribute($attribute, $on);
+        $markup = $this->helper->render($element);
+        $expect = $attribute;
+
+        $this->assertStringContainsString(
+            $expect,
+            $markup,
+            sprintf("Enabled value for %s should be '%s'; received %s", $attribute, $on, $markup)
+        );
+
+        $expect = sprintf('%s="%s"', $attribute, $on);
+        $this->assertStringNotContainsString(
+            $expect,
+            $markup,
+            sprintf("Enabled value for %s should not be '%s'; received %s", $attribute, $on, $markup)
+        );
+
+        $element->setAttribute($attribute, $off);
+        $markup = $this->helper->render($element);
+
+        if ($off !== '') {
+            $expect = sprintf('%s="%s"', $attribute, $off);
+
+            $this->assertStringContainsString(
+                $expect,
+                $markup,
+                sprintf("Disabled value for %s should be '%s'; received %s", $attribute, $off, $markup)
+            );
+        } else {
+            $expect = $attribute;
+
+            $this->assertStringNotContainsString(
+                $expect,
+                $markup,
+                sprintf('Disabled value for %s should not be rendered; received %s', $attribute, $markup)
+            );
+        }
     }
 
     public function testRendersValueAttributeAsTextareaContent()


### PR DESCRIPTION
Signed-off-by: Thomas Müller <mimmi20@live.de>

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | yes/no (if you see the chaged rendering result as BC then "yes", "no" otherwise)
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

HTML5 allows to write boolean attributes like `disabled` or `required` to write without their values, if they are true. As a result the attribute will not be rendered as `disabled="disabled"`, but only as `disabled`.
