### PR TITLE
Mark annotation manager and parser as deprecated for 2.17.0 release

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -27,7 +27,7 @@
     <env name="TESTS_LAMINAS_OB_ENABLED" value="false"/>
     <!-- Enable this if you have installed Doctrine\Common on the
              include_path or via composer. -->
-    <env name="TESTS_LAMINAS_FORM_ANNOTATION_SUPPORT" value="false"/>
+    <env name="TESTS_LAMINAS_FORM_ANNOTATION_SUPPORT" value="true"/>
     <!-- Enable this if you have installed Laminas\ReCaptcha on the
              include_path or via Composer. -->
     <env name="TESTS_LAMINAS_FORM_RECAPTCHA_SUPPORT" value="false"/>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -33,6 +33,15 @@
     </MixedAssignment>
   </file>
   <file src="src/Annotation/AnnotationBuilder.php">
+    <DeprecatedMethod occurrences="3">
+      <code>getAnnotationManager</code>
+      <code>getAnnotationParser</code>
+      <code>setAnnotationManager</code>
+    </DeprecatedMethod>
+    <DeprecatedProperty occurrences="2">
+      <code>$this-&gt;annotationManager</code>
+      <code>$this-&gt;annotationParser</code>
+    </DeprecatedProperty>
     <DocblockTypeContradiction occurrences="3">
       <code>! is_string($entity)</code>
       <code>null === $this-&gt;annotationParser</code>
@@ -104,6 +113,9 @@
     <DeprecatedInterface occurrences="1">
       <code>AnnotationBuilderFactory</code>
     </DeprecatedInterface>
+    <DeprecatedMethod occurrences="1">
+      <code>getAnnotationParser</code>
+    </DeprecatedMethod>
     <MissingReturnType occurrences="1">
       <code>injectFactory</code>
     </MissingReturnType>
@@ -2448,6 +2460,9 @@
     </RedundantCondition>
   </file>
   <file src="test/Annotation/AnnotationBuilderFactoryTest.php">
+    <DeprecatedMethod occurrences="1">
+      <code>getAnnotationParser</code>
+    </DeprecatedMethod>
     <MissingReturnType occurrences="5">
       <code>testFactoryAllowsAttachingListenersFromConfiguration</code>
       <code>testFactoryAllowsInjectingAnnotationsFromConfiguration</code>
@@ -2463,15 +2478,13 @@
     </MixedAssignment>
   </file>
   <file src="test/Annotation/AnnotationBuilderTest.php">
-    <ArgumentTypeCoercion occurrences="24">
+    <ArgumentTypeCoercion occurrences="21">
       <code>$expectedInstance</code>
-      <code>$this-&gt;classMethodsHydratorClass</code>
       <code>$this-&gt;classMethodsHydratorClass</code>
       <code>$this-&gt;classMethodsHydratorClass</code>
       <code>$this-&gt;objectPropertyHydratorClass</code>
       <code>'ArrayObject'</code>
       <code>'LaminasTest\Form\TestAsset\Annotation\Element'</code>
-      <code>'LaminasTest\Form\TestAsset\Annotation\Entity'</code>
       <code>'LaminasTest\Form\TestAsset\Annotation\Entity'</code>
       <code>'LaminasTest\Form\TestAsset\Annotation\Form'</code>
       <code>'LaminasTest\Form\TestAsset\Annotation\InputFilter'</code>
@@ -2480,7 +2493,6 @@
       <code>'Laminas\Form\Element'</code>
       <code>'Laminas\Form\Element'</code>
       <code>'Laminas\Form\Element\Collection'</code>
-      <code>'Laminas\Form\Fieldset'</code>
       <code>'Laminas\Form\Fieldset'</code>
       <code>'Laminas\Form\FieldsetInterface'</code>
       <code>'Laminas\Form\FieldsetInterface'</code>
@@ -2496,12 +2508,7 @@
     <DeprecatedMethod occurrences="1">
       <code>allowEmpty</code>
     </DeprecatedMethod>
-    <InvalidArgument occurrences="1"/>
-    <MissingClosureParamType occurrences="2">
-      <code>$code</code>
-      <code>$message</code>
-    </MissingClosureParamType>
-    <MissingReturnType occurrences="22">
+    <MissingReturnType occurrences="21">
       <code>testAllowEmptyInput</code>
       <code>testAllowTypeAsElementNameInInputFilter</code>
       <code>testAllowsComposingChildEntities</code>
@@ -2521,7 +2528,6 @@
       <code>testInputFilterInputAnnotation</code>
       <code>testInputNotRequiredByDefault</code>
       <code>testInstanceElementAnnotation</code>
-      <code>testObjectElementAnnotation</code>
       <code>testOptionsAnnotationAndComposedObjectAnnotation</code>
       <code>testOptionsAnnotationAndComposedObjectAnnotationNoneCollection</code>
     </MissingReturnType>
@@ -2539,7 +2545,7 @@
       <code>$test</code>
       <code>$test[]</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="12">
+    <MixedMethodCall occurrences="11">
       <code>current</code>
       <code>current</code>
       <code>current</code>
@@ -2548,7 +2554,6 @@
       <code>getName</code>
       <code>getName</code>
       <code>getName</code>
-      <code>getUnderscoreSeparatedKeys</code>
       <code>getUnderscoreSeparatedKeys</code>
       <code>has</code>
       <code>has</code>
@@ -2580,7 +2585,7 @@
       <code>isRequired</code>
       <code>isRequired</code>
     </PossiblyUndefinedMethod>
-    <UndefinedInterfaceMethod occurrences="22">
+    <UndefinedInterfaceMethod occurrences="19">
       <code>$attributes</code>
       <code>$attributes</code>
       <code>$attributes</code>
@@ -2588,13 +2593,10 @@
       <code>current</code>
       <code>getHydrator</code>
       <code>getHydrator</code>
-      <code>getHydrator</code>
-      <code>getHydrator</code>
       <code>getIterator</code>
       <code>getIterator</code>
       <code>getIterator</code>
       <code>getLabelAttributes</code>
-      <code>getObject</code>
       <code>getObject</code>
       <code>getTargetElement</code>
       <code>getTargetElement</code>
@@ -2604,9 +2606,6 @@
       <code>has</code>
       <code>useAsBaseFieldset</code>
     </UndefinedInterfaceMethod>
-    <UnusedClosureParam occurrences="1">
-      <code>$message</code>
-    </UnusedClosureParam>
   </file>
   <file src="test/Element/CaptchaTest.php">
     <ArgumentTypeCoercion occurrences="6">

--- a/src/Annotation/AnnotationBuilder.php
+++ b/src/Annotation/AnnotationBuilder.php
@@ -62,6 +62,7 @@ class AnnotationBuilder implements EventManagerAwareInterface, FormFactoryAwareI
     protected $entity;
 
     /**
+     * @deprecated 2.17.0 Version 3.0 will use doctrine/annotations which does not have a list of allowed annotations
      * @var array Default annotations to register
      */
     protected $defaultAnnotations = [
@@ -107,6 +108,7 @@ class AnnotationBuilder implements EventManagerAwareInterface, FormFactoryAwareI
      * Set annotation manager to use when building form from annotations
      *
      * @param  AnnotationManager $annotationManager
+     * @deprecated 2.17.0 The annotation manager will replaced with doctrine/annotations in 3.0
      * @return $this
      */
     public function setAnnotationManager(AnnotationManager $annotationManager)
@@ -161,6 +163,7 @@ class AnnotationBuilder implements EventManagerAwareInterface, FormFactoryAwareI
      *
      * If none is currently set, creates one with default annotations.
      *
+     * @deprecated 2.17.0 The annotation manager will replaced with doctrine/annotations in 3.0
      * @return AnnotationManager
      */
     public function getAnnotationManager()
@@ -441,6 +444,7 @@ class AnnotationBuilder implements EventManagerAwareInterface, FormFactoryAwareI
     }
 
     /**
+     * @deprecated 2.17.0 The annotation parser will replaced with doctrine/annotations in 3.0
      * @return Parser\DoctrineAnnotationParser
      */
     public function getAnnotationParser()

--- a/src/Annotation/AnnotationBuilder.php
+++ b/src/Annotation/AnnotationBuilder.php
@@ -37,11 +37,13 @@ use function var_export;
 class AnnotationBuilder implements EventManagerAwareInterface, FormFactoryAwareInterface
 {
     /**
+     * @deprecated 2.17.0 The annotation parser will be replaced by doctrine/annotations in 3.0
      * @var Parser\DoctrineAnnotationParser
      */
     protected $annotationParser;
 
     /**
+     * @deprecated 2.17.0 The annotation manager will be replaced by doctrine/annotations in 3.0
      * @var AnnotationManager
      */
     protected $annotationManager;
@@ -108,7 +110,7 @@ class AnnotationBuilder implements EventManagerAwareInterface, FormFactoryAwareI
      * Set annotation manager to use when building form from annotations
      *
      * @param  AnnotationManager $annotationManager
-     * @deprecated 2.17.0 The annotation manager will replaced with doctrine/annotations in 3.0
+     * @deprecated 2.17.0 The annotation manager will be replaced by doctrine/annotations in 3.0
      * @return $this
      */
     public function setAnnotationManager(AnnotationManager $annotationManager)
@@ -163,7 +165,7 @@ class AnnotationBuilder implements EventManagerAwareInterface, FormFactoryAwareI
      *
      * If none is currently set, creates one with default annotations.
      *
-     * @deprecated 2.17.0 The annotation manager will replaced with doctrine/annotations in 3.0
+     * @deprecated 2.17.0 The annotation manager will be replaced by doctrine/annotations in 3.0
      * @return AnnotationManager
      */
     public function getAnnotationManager()
@@ -444,7 +446,7 @@ class AnnotationBuilder implements EventManagerAwareInterface, FormFactoryAwareI
     }
 
     /**
-     * @deprecated 2.17.0 The annotation parser will replaced with doctrine/annotations in 3.0
+     * @deprecated 2.17.0 The annotation parser will be replaced by doctrine/annotations in 3.0
      * @return Parser\DoctrineAnnotationParser
      */
     public function getAnnotationParser()

--- a/test/Annotation/AnnotationBuilderTest.php
+++ b/test/Annotation/AnnotationBuilderTest.php
@@ -359,31 +359,6 @@ class AnnotationBuilderTest extends TestCase
         $this->assertFalse($sampleinput->isRequired());
     }
 
-    public function testObjectElementAnnotation()
-    {
-        if (version_compare(PHP_VERSION, '7.0', '>=')) {
-            $this->markTestSkipped('Cannot test Object annotation in PHP 7; object is a reserved keyword');
-        }
-
-        $entity = new TestAsset\Annotation\EntityUsingObjectProperty();
-        $builder = new Annotation\AnnotationBuilder();
-
-        $phpunit = $this;
-        set_error_handler(function ($code, $message) use ($phpunit) {
-            $phpunit->assertEquals(E_USER_DEPRECATED, $code);
-        }, E_USER_DEPRECATED);
-        $form = $builder->createForm($entity);
-        restore_error_handler();
-
-        $fieldset = $form->get('object');
-        /* @var $fieldset Laminas\Form\Fieldset */
-
-        $this->assertInstanceOf('Laminas\Form\Fieldset', $fieldset);
-        $this->assertInstanceOf('LaminasTest\Form\TestAsset\Annotation\Entity', $fieldset->getObject());
-        $this->assertInstanceOf($this->classMethodsHydratorClass, $fieldset->getHydrator());
-        $this->assertFalse($fieldset->getHydrator()->getUnderscoreSeparatedKeys());
-    }
-
     public function testInstanceElementAnnotation()
     {
         $entity = new TestAsset\Annotation\EntityUsingInstanceProperty();

--- a/test/TestAsset/Annotation/EntityWithTypeAsElementName.php
+++ b/test/TestAsset/Annotation/EntityWithTypeAsElementName.php
@@ -2,7 +2,7 @@
 
 namespace LaminasTest\Form\TestAsset\Annotation;
 
-use LaminasTest\Form\Annotation;
+use Laminas\Form\Annotation;
 
 class EntityWithTypeAsElementName
 {


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Since the annotation manager and parser from `laminas/laminas-code` have been removed in `4.0`, `laminas/laminas-form` should switch to `doctrine/annotation-parser` as discussed in #104. This MR marks some elements as deprecated, which will need to be dropped in the next major release, for switching to `doctrine/annotations`.

Additionally, this MR enables annotation parsing as part of the unit tests, which has been disabled for some unknown reasons.


**Milestone:** 2.17.0
