### PR TITLE
Dropped support for servicemanager 2.x and removed unused dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,6 @@
         "laminas/laminas-inputfilter": "^2.10",
         "laminas/laminas-stdlib": "^3.3"
     },
-    "replace": {
-        "zendframework/zend-form": "^2.14.3"
-    },
     "conflict": {
         "laminas/laminas-servicemanager": "<3.0.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "laminas/laminas-stdlib": "^3.3.1"
     },
     "conflict": {
-        "laminas/laminas-servicemanager": "<3.4.0"
+        "laminas/laminas-servicemanager": "<3.6.0"
     },
     "require-dev": {
         "doctrine/annotations": "^1.11.0",
@@ -41,7 +41,7 @@
         "laminas/laminas-eventmanager": "^3.3, reuired for laminas-form annotations support",
         "laminas/laminas-i18n": "^2.11, required when using laminas-form view helpers",
         "laminas/laminas-recaptcha": "^3.3, in order to use the ReCaptcha form element",
-        "laminas/laminas-servicemanager": "^3.4, required to use the form factories or provide services",
+        "laminas/laminas-servicemanager": "^3.6, required to use the form factories or provide services",
         "laminas/laminas-view": "^2.12, required for using the laminas-form view helpers"
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,7 @@
         "php": "^7.3 || ~8.0.0",
         "laminas/laminas-hydrator": "^3.2 || ^4.0",
         "laminas/laminas-inputfilter": "^2.10",
-        "laminas/laminas-stdlib": "^3.3",
-        "laminas/laminas-zendframework-bridge": "^1.1"
+        "laminas/laminas-stdlib": "^3.3"
     },
     "replace": {
         "zendframework/zend-form": "^2.14.3"
@@ -22,7 +21,6 @@
     },
     "require-dev": {
         "doctrine/annotations": "^1.11.0",
-        "laminas/laminas-cache": "^2.9.0",
         "laminas/laminas-captcha": "^2.9.0",
         "laminas/laminas-coding-standard": "^1.0.0",
         "laminas/laminas-escaper": "^2.6.1",

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,9 @@
     "replace": {
         "zendframework/zend-form": "^2.14.3"
     },
+    "conflict": {
+        "laminas/laminas-servicemanager": "<3.0.0"
+    },
     "require-dev": {
         "doctrine/annotations": "^1.11.0",
         "laminas/laminas-cache": "^2.9.0",

--- a/composer.json
+++ b/composer.json
@@ -9,40 +9,40 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": "^7.3 || ~8.0.0",
-        "laminas/laminas-hydrator": "^3.2 || ^4.0",
-        "laminas/laminas-inputfilter": "^2.10",
-        "laminas/laminas-stdlib": "^3.3"
+        "laminas/laminas-hydrator": "^3.2.0 || ^4.1.0",
+        "laminas/laminas-inputfilter": "^2.12.0",
+        "laminas/laminas-stdlib": "^3.3.1"
     },
     "conflict": {
-        "laminas/laminas-servicemanager": "<3.0.0"
+        "laminas/laminas-servicemanager": "<3.4.0"
     },
     "require-dev": {
         "doctrine/annotations": "^1.11.0",
-        "laminas/laminas-captcha": "^2.9.0",
+        "laminas/laminas-captcha": "^2.10.0",
         "laminas/laminas-coding-standard": "^1.0.0",
-        "laminas/laminas-escaper": "^2.6.1",
-        "laminas/laminas-eventmanager": "^3.3.0",
-        "laminas/laminas-filter": "^2.9.4",
-        "laminas/laminas-i18n": "^2.10.3",
-        "laminas/laminas-recaptcha": "^3.2.0",
-        "laminas/laminas-servicemanager": "^3.4.1",
-        "laminas/laminas-session": "^2.9.3",
-        "laminas/laminas-text": "^2.7.1",
-        "laminas/laminas-validator": "^2.13.4",
-        "laminas/laminas-view": "^2.11.4",
-        "phpspec/prophecy-phpunit": "^2.0",
-        "phpunit/phpunit": "^9.4.2",
+        "laminas/laminas-escaper": "^2.7.0",
+        "laminas/laminas-eventmanager": "^3.3.1",
+        "laminas/laminas-filter": "^2.11.0",
+        "laminas/laminas-i18n": "^2.11.1",
+        "laminas/laminas-recaptcha": "^3.3.0",
+        "laminas/laminas-servicemanager": "^3.6.4",
+        "laminas/laminas-session": "^2.10.0",
+        "laminas/laminas-text": "^2.8.1",
+        "laminas/laminas-validator": "^2.14.4",
+        "laminas/laminas-view": "^2.12.0",
+        "phpspec/prophecy-phpunit": "^2.0.1",
+        "phpunit/phpunit": "^9.5.4",
         "psalm/plugin-phpunit": "^0.15.1",
-        "vimeo/psalm": "^4.7"
+        "vimeo/psalm": "^4.7.3"
     },
     "suggest": {
         "doctrine/annotations": "^1.11, required to use laminas-form annotations support",
-        "laminas/laminas-captcha": "^2.9, required for using CAPTCHA form elements",
+        "laminas/laminas-captcha": "^2.10, required for using CAPTCHA form elements",
         "laminas/laminas-eventmanager": "^3.3, reuired for laminas-form annotations support",
-        "laminas/laminas-i18n": "^2.10, required when using laminas-form view helpers",
-        "laminas/laminas-recaptcha": "^3.2, in order to use the ReCaptcha form element",
-        "laminas/laminas-servicemanager": "^3.4.1, required to use the form factories or provide services",
-        "laminas/laminas-view": "^2.11.4, required for using the laminas-form view helpers"
+        "laminas/laminas-i18n": "^2.11, required when using laminas-form view helpers",
+        "laminas/laminas-recaptcha": "^3.3, in order to use the ReCaptcha form element",
+        "laminas/laminas-servicemanager": "^3.4, required to use the form factories or provide services",
+        "laminas/laminas-view": "^2.12, required for using the laminas-form view helpers"
     },
     "config": {
         "sort-packages": true

--- a/docs/book/advanced.md
+++ b/docs/book/advanced.md
@@ -395,22 +395,13 @@ namespace Application\Form;
 
 use Album\Model\AlbumTable;
 use Interop\Container\ContainerInterface;
-use Laminas\ServiceManager\FactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 
 class AlbumFieldsetFactory implements FactoryInterface
 {
     public function __invoke(ContainerInterface $container, $name, array $options = null)
     {
         return new AlbumFieldset($container->get(AlbumTable::class));
-    }
-
-    public function createService(ServiceLocatorInterface $formManager)
-    {
-        return $this(
-            $formManager->getServiceLocator() ?: $formManager,
-            AlbumFieldset::class
-        );
     }
 }
 ```

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -91,9 +91,6 @@
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Annotation/AnnotationBuilderFactory.php">
-    <DeprecatedInterface occurrences="1">
-      <code>AnnotationBuilderFactory</code>
-    </DeprecatedInterface>
     <MissingReturnType occurrences="1">
       <code>injectFactory</code>
     </MissingReturnType>
@@ -115,9 +112,6 @@
       <code>$listener</code>
       <code>$listenerName</code>
     </MixedAssignment>
-    <ParamNameMismatch occurrences="1">
-      <code>$container</code>
-    </ParamNameMismatch>
   </file>
   <file src="src/Annotation/ComposedObject.php">
     <MixedInferredReturnType occurrences="2">
@@ -922,32 +916,13 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/ElementFactory.php">
-    <DeprecatedInterface occurrences="1">
-      <code>ElementFactory</code>
-    </DeprecatedInterface>
-    <DocblockTypeContradiction occurrences="1">
-      <code>is_array($creationOptions)</code>
-    </DocblockTypeContradiction>
     <InvalidStringClass occurrences="1">
       <code>new $requestedName($name, $options)</code>
     </InvalidStringClass>
-    <MissingPropertyType occurrences="1">
-      <code>$creationOptions</code>
-    </MissingPropertyType>
-    <MissingReturnType occurrences="1">
-      <code>setCreationOptions</code>
-    </MissingReturnType>
-    <MixedArgument occurrences="2">
-      <code>$this-&gt;creationOptions</code>
-      <code>$this-&gt;creationOptions</code>
-    </MixedArgument>
     <MixedAssignment occurrences="2">
       <code>$name</code>
       <code>$options</code>
     </MixedAssignment>
-    <PossiblyNullArgument occurrences="1">
-      <code>$canonicalName</code>
-    </PossiblyNullArgument>
   </file>
   <file src="src/ElementInterface.php">
     <MissingParamType occurrences="1">
@@ -1379,9 +1354,6 @@
       <code>$container</code>
       <code>$container</code>
     </ArgumentTypeCoercion>
-    <DeprecatedInterface occurrences="1">
-      <code>FormAbstractServiceFactory</code>
-    </DeprecatedInterface>
     <MissingConstructor occurrences="2">
       <code>$config</code>
       <code>$factory</code>
@@ -1469,27 +1441,12 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="src/FormElementManagerFactory.php">
-    <DeprecatedInterface occurrences="1">
-      <code>FormElementManagerFactory</code>
-    </DeprecatedInterface>
-    <DeprecatedProperty occurrences="1">
-      <code>$this-&gt;creationOptions</code>
-    </DeprecatedProperty>
-    <MissingParamType occurrences="3">
+    <MissingParamType occurrences="1">
       <code>$name</code>
-      <code>$name</code>
-      <code>$requestedName</code>
     </MissingParamType>
-    <MissingPropertyType occurrences="1">
-      <code>$creationOptions</code>
-    </MissingPropertyType>
-    <MixedArgument occurrences="2">
+    <MixedArgument occurrences="1">
       <code>$config['form_elements']</code>
-      <code>$this-&gt;creationOptions</code>
     </MixedArgument>
-    <ParamNameMismatch occurrences="1">
-      <code>$container</code>
-    </ParamNameMismatch>
   </file>
   <file src="src/FormFactoryAwareInterface.php">
     <MissingReturnType occurrences="1">
@@ -3617,20 +3574,14 @@
     </MixedMethodCall>
   </file>
   <file src="test/ElementFactoryTest.php">
-    <MissingParamType occurrences="1">
-      <code>$creationOptions</code>
-    </MissingParamType>
     <MissingPropertyType occurrences="1">
       <code>$result-&gt;args</code>
     </MissingPropertyType>
-    <MissingReturnType occurrences="4">
-      <code>invalidCreationOptions</code>
-      <code>testInvalidCreationOptionsException</code>
+    <MissingReturnType occurrences="2">
       <code>testValidCreationOptions</code>
       <code>validCreationOptions</code>
     </MissingReturnType>
-    <MixedArgument occurrences="2">
-      <code>$creationOptions</code>
+    <MixedArgument occurrences="1">
       <code>$creationOptions</code>
     </MixedArgument>
   </file>
@@ -4032,17 +3983,17 @@
       <code>$validators</code>
     </MixedAssignment>
     <MixedMethodCall occurrences="39">
-      <code>canCreateServiceWithName</code>
-      <code>canCreateServiceWithName</code>
-      <code>canCreateServiceWithName</code>
-      <code>canCreateServiceWithName</code>
-      <code>canCreateServiceWithName</code>
-      <code>canCreateServiceWithName</code>
-      <code>canCreateServiceWithName</code>
-      <code>canCreateServiceWithName</code>
-      <code>canCreateServiceWithName</code>
-      <code>createServiceWithName</code>
-      <code>createServiceWithName</code>
+      <code>__invoke</code>
+      <code>__invoke</code>
+      <code>canCreate</code>
+      <code>canCreate</code>
+      <code>canCreate</code>
+      <code>canCreate</code>
+      <code>canCreate</code>
+      <code>canCreate</code>
+      <code>canCreate</code>
+      <code>canCreate</code>
+      <code>canCreate</code>
       <code>get</code>
       <code>get</code>
       <code>get</code>
@@ -5014,26 +4965,13 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="test/TestAsset/CustomCreatedFormFactory.php">
-    <DeprecatedInterface occurrences="1">
-      <code>CustomCreatedFormFactory</code>
-    </DeprecatedInterface>
-    <MissingPropertyType occurrences="1">
-      <code>$creationOptions</code>
-    </MissingPropertyType>
-    <MissingReturnType occurrences="1">
-      <code>setCreationOptions</code>
-    </MissingReturnType>
-    <MixedArgument occurrences="2">
+    <MixedArgument occurrences="1">
       <code>$creationString</code>
-      <code>$this-&gt;creationOptions</code>
     </MixedArgument>
     <MixedAssignment occurrences="2">
       <code>$creationString</code>
       <code>$name</code>
     </MixedAssignment>
-    <ParamNameMismatch occurrences="1">
-      <code>$container</code>
-    </ParamNameMismatch>
   </file>
   <file src="test/TestAsset/CustomFieldsetHelper.php">
     <InvalidFunctionCall occurrences="1">
@@ -5198,24 +5136,9 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="test/TestAsset/FieldsetWithDependencyFactory.php">
-    <DeprecatedInterface occurrences="1">
-      <code>FieldsetWithDependencyFactory</code>
-    </DeprecatedInterface>
-    <MissingPropertyType occurrences="1">
-      <code>$creationOptions</code>
-    </MissingPropertyType>
-    <MissingReturnType occurrences="1">
-      <code>setCreationOptions</code>
-    </MissingReturnType>
-    <MixedArgument occurrences="1">
-      <code>$this-&gt;creationOptions</code>
-    </MixedArgument>
     <MixedAssignment occurrences="1">
       <code>$name</code>
     </MixedAssignment>
-    <ParamNameMismatch occurrences="1">
-      <code>$container</code>
-    </ParamNameMismatch>
   </file>
   <file src="test/TestAsset/FieldsetWithInputFilter.php">
     <PropertyNotSetInConstructor occurrences="3">

--- a/src/Annotation/AnnotationBuilder.php
+++ b/src/Annotation/AnnotationBuilder.php
@@ -372,21 +372,4 @@ class AnnotationBuilder implements EventManagerAwareInterface, FormFactoryAwareI
 
         return (bool) $results->last();
     }
-
-    /**
-     * Checks if the object has this class as one of its parents
-     *
-     * @see https://bugs.php.net/bug.php?id=53727
-     * @see https://github.com/zendframework/zf2/pull/1807
-     *
-     * @deprecated since laminas 2.3 requires PHP >= 5.3.23
-     *
-     * @param string $className
-     * @param string $type
-     * @return bool
-     */
-    protected static function isSubclassOf($className, $type)
-    {
-        return is_subclass_of($className, $type);
-    }
 }

--- a/src/Annotation/AnnotationBuilderFactory.php
+++ b/src/Annotation/AnnotationBuilderFactory.php
@@ -7,8 +7,7 @@ use Laminas\EventManager\EventManagerInterface;
 use Laminas\EventManager\ListenerAggregateInterface;
 use Laminas\Form\Factory;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
-use Laminas\ServiceManager\FactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 
 use function is_array;
 use function sprintf;
@@ -39,19 +38,6 @@ class AnnotationBuilderFactory implements FactoryInterface
         $this->injectListeners($config, $eventManager, $container);
 
         return $annotationBuilder;
-    }
-
-    /**
-     * Create and return AnnotationBuilder instance
-     *
-     * For use with laminas-servicemanager v2; proxies to __invoke().
-     *
-     * @param ServiceLocatorInterface $container
-     * @return AnnotationBuilder
-     */
-    public function createService(ServiceLocatorInterface $container)
-    {
-        return $this($container, AnnotationBuilder::class);
     }
 
     /**

--- a/src/ElementFactory.php
+++ b/src/ElementFactory.php
@@ -3,21 +3,10 @@
 namespace Laminas\Form;
 
 use Interop\Container\ContainerInterface;
-use Laminas\ServiceManager\Exception\InvalidServiceException;
-use Laminas\ServiceManager\FactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
-use Traversable;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 
 use function array_pop;
-use function class_exists;
 use function explode;
-use function get_class;
-use function gettype;
-use function is_array;
-use function is_object;
-use function is_string;
-use function iterator_to_array;
-use function sprintf;
 use function strtolower;
 
 /**
@@ -25,37 +14,6 @@ use function strtolower;
  */
 final class ElementFactory implements FactoryInterface
 {
-    /**
-     * Options to pass to the constructor (when used in v2), if any.
-     *
-     * @param null|array
-     */
-    private $creationOptions;
-
-    /**
-     * @param null|array|Traversable $creationOptions
-     * @throws InvalidServiceException if $creationOptions cannot be coerced to
-     *     an array.
-     */
-    public function __construct($creationOptions = null)
-    {
-        if (null === $creationOptions) {
-            return;
-        }
-
-        if ($creationOptions instanceof Traversable) {
-            $creationOptions = iterator_to_array($creationOptions);
-        } elseif (! is_array($creationOptions)) {
-            throw new InvalidServiceException(sprintf(
-                '%s cannot use non-array, non-traversable, non-null creation options; received %s',
-                __CLASS__,
-                is_object($creationOptions) ? get_class($creationOptions) : gettype($creationOptions)
-            ));
-        }
-
-        $this->setCreationOptions($creationOptions);
-    }
-
     /**
      * Create an instance of the requested class name.
      *
@@ -83,56 +41,5 @@ final class ElementFactory implements FactoryInterface
         }
 
         return new $requestedName($name, $options);
-    }
-
-    /**
-     * Create an instance of the named service.
-     *
-     * First, it checks if `$canonicalName` resolves to a class, and, if so, uses
-     * that value to proxy to `__invoke()`.
-     *
-     * Next, if `$requestedName` is non-empty and resolves to a class, this
-     * method uses that value to proxy to `__invoke()`.
-     *
-     * Finally, if the above each fail, it raises an exception.
-     *
-     * The approach above is performed as version 2 has two distinct behaviors
-     * under which factories are invoked:
-     *
-     * - If an alias was used, $canonicalName is the resolved name, and
-     *   $requestedName is the service name requested, in which case $canonicalName
-     *   is likely the qualified class name;
-     * - Otherwise, $canonicalName is the normalized name, and $requestedName
-     *   is the original service name requested (typically the qualified class name).
-     *
-     * @param ServiceLocatorInterface $serviceLocator
-     * @param null|string $canonicalName
-     * @param null|string $requestedName
-     * @return object
-     * @throws InvalidServiceException
-     */
-    public function createService(ServiceLocatorInterface $serviceLocator, $canonicalName = null, $requestedName = null)
-    {
-        if (class_exists($canonicalName)) {
-            return $this($serviceLocator, $canonicalName, $this->creationOptions);
-        }
-
-        if (is_string($requestedName) && class_exists($requestedName)) {
-            return $this($serviceLocator, $requestedName, $this->creationOptions);
-        }
-
-        throw new InvalidServiceException(sprintf(
-            '%s requires that the requested name is provided on invocation; please update your tests or '
-            . 'consuming container',
-            __CLASS__
-        ));
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setCreationOptions(array $creationOptions)
-    {
-        $this->creationOptions = $creationOptions;
     }
 }

--- a/src/FormAbstractServiceFactory.php
+++ b/src/FormAbstractServiceFactory.php
@@ -4,7 +4,7 @@ namespace Laminas\Form;
 
 use Interop\Container\ContainerInterface;
 use Laminas\InputFilter\InputFilterInterface;
-use Laminas\ServiceManager\AbstractFactoryInterface;
+use Laminas\ServiceManager\Factory\AbstractFactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 
 use function is_array;
@@ -67,32 +67,6 @@ class FormAbstractServiceFactory implements AbstractFactoryInterface
         return isset($config[$requestedName])
             && is_array($config[$requestedName])
             && ! empty($config[$requestedName]);
-    }
-
-    /**
-     * Can we create the requested service? (v2)
-     *
-     * @param  ServiceLocatorInterface $serviceLocator
-     * @param  string $name Service name (as resolved by ServiceManager)
-     * @param  string $requestedName Name by which service was requested
-     * @return bool
-     */
-    public function canCreateServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
-    {
-        return $this->canCreate($serviceLocator, $requestedName);
-    }
-
-    /**
-     * Create a form (v2)
-     *
-     * @param  ServiceLocatorInterface $serviceLocator
-     * @param  string $name Service name (as resolved by ServiceManager)
-     * @param  string $requestedName Name by which service was requested
-     * @return FormInterface
-     */
-    public function createServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
-    {
-        return $this($serviceLocator, $requestedName);
     }
 
     /**

--- a/src/FormElementManagerFactory.php
+++ b/src/FormElementManagerFactory.php
@@ -5,23 +5,12 @@ namespace Laminas\Form;
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\AbstractPluginManager;
 use Laminas\ServiceManager\Config;
-use Laminas\ServiceManager\FactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 
 use function is_array;
-use function method_exists;
 
 class FormElementManagerFactory implements FactoryInterface
 {
-    /**
-     * laminas-servicemanager v2 support for invocation options.
-     *
-     * @param array
-     *
-     * @deprecated Call \Laminas\Form\FormElementManagerFactory::__invoke with 3rd parameter as options instead
-     */
-    protected $creationOptions;
-
     /**
      * {@inheritDoc}
      *
@@ -29,7 +18,7 @@ class FormElementManagerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $name, array $options = null)
     {
-        $pluginManager = new \Laminas\Form\FormElementManager($container, $options ?: []);
+        $pluginManager = new FormElementManager($container, $options ?: []);
 
         // If this is in a laminas-mvc application, the ServiceListener will inject
         // merged configuration during bootstrap.
@@ -53,32 +42,5 @@ class FormElementManagerFactory implements FactoryInterface
         (new Config($config['form_elements']))->configureServiceManager($pluginManager);
 
         return $pluginManager;
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @return AbstractPluginManager
-     */
-    public function createService(ServiceLocatorInterface $container, $name = null, $requestedName = null)
-    {
-        return $this(
-            $container,
-            $requestedName ?: __NAMESPACE__ . '\FormElementManager',
-            $this->creationOptions
-        );
-    }
-
-    /**
-     * laminas-servicemanager v2 support for invocation options.
-     *
-     * @param array $options
-     * @return void
-     *
-     * @deprecated Call \Laminas\Form\FormElementManagerFactory::__invoke with 3rd parameter as options instead
-     */
-    public function setCreationOptions(array $options)
-    {
-        $this->creationOptions = $options;
     }
 }

--- a/test/ElementFactoryTest.php
+++ b/test/ElementFactoryTest.php
@@ -2,10 +2,8 @@
 
 namespace LaminasTest\Form;
 
-use ArrayObject;
 use Interop\Container\ContainerInterface;
 use Laminas\Form\ElementFactory;
-use Laminas\ServiceManager\Exception\InvalidServiceException;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use LaminasTest\Form\TestAsset\ArgumentRecorder;
 use PHPUnit\Framework\TestCase;
@@ -21,7 +19,6 @@ class ElementFactoryTest extends TestCase
 
     public function validCreationOptions()
     {
-        yield 'ArrayObject' => [new ArrayObject(['key' => 'value']), ['key' => 'value']];
         yield 'array' => [['key' => 'value'], ['key' => 'value']];
         yield 'empty-array' => [[], []];
         yield 'null' => [null, []];
@@ -39,28 +36,9 @@ class ElementFactoryTest extends TestCase
             ->willImplement(ContainerInterface::class)
             ->reveal();
 
-        $factory = new ElementFactory($creationOptions);
-        $result = $factory->createService($container, ArgumentRecorder::class);
+        $factory = new ElementFactory();
+        $result = $factory->__invoke($container, ArgumentRecorder::class, $creationOptions);
         $this->assertInstanceOf(ArgumentRecorder::class, $result);
         $this->assertSame(['argumentrecorder', $expectedValue], $result->args);
-    }
-
-    public function invalidCreationOptions()
-    {
-        yield 'object' => [(object) ['key' => 'val']];
-        yield 'int' => [PHP_INT_MAX];
-        yield 'string' => [uniqid('', true)];
-    }
-
-    /**
-     * @dataProvider invalidCreationOptions
-     *
-     * @param $creationOptions
-     */
-    public function testInvalidCreationOptionsException($creationOptions)
-    {
-        $this->expectException(InvalidServiceException::class);
-        $this->expectExceptionMessage('cannot use non-array, non-traversable, non-null creation options;');
-        new ElementFactory($creationOptions);
     }
 }

--- a/test/FormAbstractServiceFactoryTest.php
+++ b/test/FormAbstractServiceFactoryTest.php
@@ -44,31 +44,31 @@ class FormAbstractServiceFactoryTest extends TestCase
 
     public function testMissingConfigServiceIndicatesCannotCreateForm()
     {
-        $this->assertFalse($this->forms->canCreateServiceWithName($this->services, 'foo', 'foo'));
+        $this->assertFalse($this->forms->canCreate($this->services, 'foo'));
     }
 
     public function testMissingFormServicePrefixIndicatesCannotCreateForm()
     {
         $this->services->setService('config', []);
-        $this->assertFalse($this->forms->canCreateServiceWithName($this->services, 'foo', 'foo'));
+        $this->assertFalse($this->forms->canCreate($this->services, 'foo'));
     }
 
     public function testMissingFormManagerConfigIndicatesCannotCreateForm()
     {
         $this->services->setService('config', []);
-        $this->assertFalse($this->forms->canCreateServiceWithName($this->services, 'Form\Foo', 'Form\Foo'));
+        $this->assertFalse($this->forms->canCreate($this->services, 'Form\Foo'));
     }
 
     public function testInvalidFormManagerConfigIndicatesCannotCreateForm()
     {
         $this->services->setService('config', ['forms' => 'string']);
-        $this->assertFalse($this->forms->canCreateServiceWithName($this->services, 'Form\Foo', 'Form\Foo'));
+        $this->assertFalse($this->forms->canCreate($this->services, 'Form\Foo'));
     }
 
     public function testEmptyFormManagerConfigIndicatesCannotCreateForm()
     {
         $this->services->setService('config', ['forms' => []]);
-        $this->assertFalse($this->forms->canCreateServiceWithName($this->services, 'Form\Foo', 'Form\Foo'));
+        $this->assertFalse($this->forms->canCreate($this->services, 'Form\Foo'));
     }
 
     public function testMissingFormConfigIndicatesCannotCreateForm()
@@ -78,7 +78,7 @@ class FormAbstractServiceFactoryTest extends TestCase
                 'Bar' => [],
             ],
         ]);
-        $this->assertFalse($this->forms->canCreateServiceWithName($this->services, 'Form\Foo', 'Form\Foo'));
+        $this->assertFalse($this->forms->canCreate($this->services, 'Form\Foo'));
     }
 
     public function testInvalidFormConfigIndicatesCannotCreateForm()
@@ -88,7 +88,7 @@ class FormAbstractServiceFactoryTest extends TestCase
                 'Foo' => 'string',
             ],
         ]);
-        $this->assertFalse($this->forms->canCreateServiceWithName($this->services, 'Foo', 'Foo'));
+        $this->assertFalse($this->forms->canCreate($this->services, 'Foo'));
     }
 
     public function testEmptyFormConfigIndicatesCannotCreateForm()
@@ -98,7 +98,7 @@ class FormAbstractServiceFactoryTest extends TestCase
                 'Foo' => [],
             ],
         ]);
-        $this->assertFalse($this->forms->canCreateServiceWithName($this->services, 'Foo', 'Foo'));
+        $this->assertFalse($this->forms->canCreate($this->services, 'Foo'));
     }
 
     public function testPopulatedFormConfigIndicatesFormCanBeCreated()
@@ -111,7 +111,7 @@ class FormAbstractServiceFactoryTest extends TestCase
                 ],
             ],
         ]);
-        $this->assertTrue($this->forms->canCreateServiceWithName($this->services, 'Foo', 'Foo'));
+        $this->assertTrue($this->forms->canCreate($this->services, 'Foo'));
     }
 
     public function testFormCanBeCreatedViaInteractionOfAllManagers()
@@ -136,7 +136,7 @@ class FormAbstractServiceFactoryTest extends TestCase
         ];
         $config = ['forms' => ['Foo' => $formConfig]];
         $this->services->setService('config', $config);
-        $form = $this->forms->createServiceWithName($this->services, 'Foo', 'Foo');
+        $form = $this->forms->__invoke($this->services, 'Foo');
         $this->assertInstanceOf('Laminas\Form\Form', $form);
 
         $hydrator = $form->getHydrator();
@@ -189,7 +189,7 @@ class FormAbstractServiceFactoryTest extends TestCase
         ];
         $config = ['forms' => ['Foo' => $formConfig]];
         $this->services->setService('config', $config);
-        $form = $this->forms->createServiceWithName($this->services, 'Foo', 'Foo');
+        $form = $this->forms->__invoke($this->services, 'Foo');
         $this->assertInstanceOf('Laminas\Form\Form', $form);
 
         $hydrator = $form->getHydrator();

--- a/test/TestAsset/CustomCreatedFormFactory.php
+++ b/test/TestAsset/CustomCreatedFormFactory.php
@@ -4,13 +4,10 @@ namespace LaminasTest\Form\TestAsset;
 
 use DateTime;
 use Interop\Container\ContainerInterface;
-use Laminas\ServiceManager\FactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 
 class CustomCreatedFormFactory implements FactoryInterface
 {
-    private $creationOptions = [];
-
     public function __invoke(ContainerInterface $container, $name, array $options = null)
     {
         $options = $options ?: [];
@@ -31,15 +28,5 @@ class CustomCreatedFormFactory implements FactoryInterface
 
         $form = new CustomCreatedForm($created, $name, $options);
         return $form;
-    }
-
-    public function createService(ServiceLocatorInterface $container)
-    {
-        return $this($container, CustomCreatedForm::class, $this->creationOptions);
-    }
-
-    public function setCreationOptions(array $options)
-    {
-        $this->creationOptions = $options;
     }
 }

--- a/test/TestAsset/FieldsetWithDependencyFactory.php
+++ b/test/TestAsset/FieldsetWithDependencyFactory.php
@@ -3,13 +3,10 @@
 namespace LaminasTest\Form\TestAsset;
 
 use Interop\Container\ContainerInterface;
-use Laminas\ServiceManager\FactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 
 class FieldsetWithDependencyFactory implements FactoryInterface
 {
-    private $creationOptions = [];
-
     public function __invoke(ContainerInterface $container, $name, array $options = null)
     {
         $options = $options ?: [];
@@ -24,15 +21,5 @@ class FieldsetWithDependencyFactory implements FactoryInterface
         $form->setDependency(new InputFilter());
 
         return $form;
-    }
-
-    public function createService(ServiceLocatorInterface $container)
-    {
-        return $this($container, CustomCreatedForm::class, $this->creationOptions);
-    }
-
-    public function setCreationOptions(array $options)
-    {
-        $this->creationOptions = $options;
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes (unused dependencies)
| BC Break      | yes (dropped support for servicemanager 2.x)
| New Feature   | no
| RFC           | yes
| QA            | no

### Description

This MR is based on top of #111 and adds:

 - dropping `laminas/laminas-zendframework-bridge` and remove `replace` section in `composer.json`
 - dropping `laminas/laminas-cache` from `require-dev` (looks like its not used anywhere?!)
 - refactor all factories to `laminas-servicemanager:^3.0` and add a conflict for `laminas-servicemanager:<3.0`

**Milestone:** 3.0.0
