### PR TITLE
Element\Select selecting incorrect values when using floats (issue #52)

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -8316,7 +8316,7 @@
     <MissingParamType occurrences="1">
       <code>$options</code>
     </MissingParamType>
-    <MissingReturnType occurrences="29">
+    <MissingReturnType occurrences="30">
       <code>getElement</code>
       <code>getElementWithObjectIdentifiers</code>
       <code>getScalarOptionsDataProvider</code>
@@ -8331,6 +8331,7 @@
       <code>testCanOnlyMarkSingleOptionAsSelectedIfMultipleAttributeIsDisabled</code>
       <code>testCanTranslateContent</code>
       <code>testCanTranslateOptGroupLabel</code>
+      <code>testComparisonOfSelectedValuesIsPerformedInStrictMode</code>
       <code>testCreatesSelectWithOptionsFromAttribute</code>
       <code>testDoesNotRenderEmptyOptionByDefault</code>
       <code>testDoesNotThrowExceptionIfNameIsZero</code>
@@ -8347,7 +8348,8 @@
       <code>testScalarOptionValues</code>
       <code>testTranslatorMethods</code>
     </MissingReturnType>
-    <MixedArgument occurrences="27">
+    <MixedArgument occurrences="28">
+      <code>$markup</code>
       <code>$markup</code>
       <code>$markup</code>
       <code>$markup</code>
@@ -8389,7 +8391,7 @@
       <code>$options[1]</code>
       <code>$options[1]</code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="43">
+    <MixedAssignment occurrences="44">
       <code>$element</code>
       <code>$element</code>
       <code>$element</code>
@@ -8405,6 +8407,7 @@
       <code>$element</code>
       <code>$element</code>
       <code>$label</code>
+      <code>$markup</code>
       <code>$markup</code>
       <code>$markup</code>
       <code>$markup</code>
@@ -8454,12 +8457,13 @@
       <code>setValueOptions</code>
       <code>setValueOptions</code>
     </MixedMethodCall>
-    <UndefinedMethod occurrences="28">
+    <UndefinedMethod occurrences="29">
       <code>__invoke</code>
       <code>__invoke</code>
       <code>__invoke</code>
       <code>__invoke</code>
       <code>__invoke</code>
+      <code>render</code>
       <code>render</code>
       <code>render</code>
       <code>render</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2371,9 +2371,10 @@
     <MissingReturnType occurrences="1">
       <code>renderHiddenElement</code>
     </MissingReturnType>
-    <MixedArgument occurrences="2">
+    <MixedArgument occurrences="3">
       <code>$escapeHtml($label)</code>
       <code>$label</code>
+      <code>$selectedOptions</code>
     </MixedArgument>
     <MixedAssignment occurrences="6">
       <code>$disabled</code>

--- a/src/View/Helper/FormSelect.php
+++ b/src/View/Helper/FormSelect.php
@@ -6,8 +6,8 @@ use Laminas\Form\Element\Hidden;
 use Laminas\Form\Element\Select as SelectElement;
 use Laminas\Form\ElementInterface;
 use Laminas\Form\Exception;
-
 use Laminas\Stdlib\ArrayUtils;
+
 use function array_key_exists;
 use function array_merge;
 use function compact;

--- a/src/View/Helper/FormSelect.php
+++ b/src/View/Helper/FormSelect.php
@@ -7,6 +7,7 @@ use Laminas\Form\Element\Select as SelectElement;
 use Laminas\Form\ElementInterface;
 use Laminas\Form\Exception;
 
+use Laminas\Stdlib\ArrayUtils;
 use function array_key_exists;
 use function array_merge;
 use function compact;
@@ -204,7 +205,7 @@ class FormSelect extends AbstractHelper
                 $disabled = $optionSpec['disabled'];
             }
 
-            if ($this->inArrayWithStringConversion($value, $selectedOptions)) {
+            if (ArrayUtils::inArray($value, $selectedOptions, true)) {
                 $selected = true;
             }
 
@@ -298,16 +299,6 @@ class FormSelect extends AbstractHelper
         }
 
         return $value;
-    }
-
-    protected function inArrayWithStringConversion($needle, array $haystack)
-    {
-        $needle = (string) $needle;
-        foreach ($haystack as &$value) {
-            $value = (string) $value;
-        }
-
-        return in_array($needle, $haystack, true);
     }
 
     protected function renderHiddenElement(ElementInterface $element)

--- a/src/View/Helper/FormSelect.php
+++ b/src/View/Helper/FormSelect.php
@@ -6,7 +6,6 @@ use Laminas\Form\Element\Hidden;
 use Laminas\Form\Element\Select as SelectElement;
 use Laminas\Form\ElementInterface;
 use Laminas\Form\Exception;
-use Laminas\Stdlib\ArrayUtils;
 
 use function array_key_exists;
 use function array_merge;
@@ -205,7 +204,7 @@ class FormSelect extends AbstractHelper
                 $disabled = $optionSpec['disabled'];
             }
 
-            if (ArrayUtils::inArray($value, $selectedOptions)) {
+            if ($this->inArrayWithStringConversion($value, $selectedOptions)) {
                 $selected = true;
             }
 
@@ -299,6 +298,16 @@ class FormSelect extends AbstractHelper
         }
 
         return $value;
+    }
+
+    protected function inArrayWithStringConversion($needle, array $haystack)
+    {
+        $needle = (string) $needle;
+        foreach ($haystack as &$value) {
+            $value = (string) $value;
+        }
+
+        return in_array($needle, $haystack, true);
     }
 
     protected function renderHiddenElement(ElementInterface $element)

--- a/src/View/Helper/FormSelect.php
+++ b/src/View/Helper/FormSelect.php
@@ -205,7 +205,8 @@ class FormSelect extends AbstractHelper
                 $disabled = $optionSpec['disabled'];
             }
 
-            if (ArrayUtils::inArray($value, $selectedOptions, true)) {
+            $stringSelectedOptions = array_map('\\strval', $selectedOptions);
+            if (ArrayUtils::inArray((string) $value, $stringSelectedOptions, true)) {
                 $selected = true;
             }
 

--- a/test/View/Helper/FormSelectTest.php
+++ b/test/View/Helper/FormSelectTest.php
@@ -441,4 +441,26 @@ class FormSelectTest extends CommonTestCase
         $this->assertMatchesRegularExpression('#option .*?value="42" selected="selected"#', $markup);
         $this->assertDoesNotMatchRegularExpression('#option .*?value="43" selected="selected"#', $markup);
     }
+
+    public function testComparisonOfSelectedValuesIsPerformedInStrictMode()
+    {
+        $select = new SelectElement('language');
+        $select->setLabel('Which is your mother tongue?');
+        $select->setAttribute('multiple', true);
+        $select->setValueOptions([
+            '1.1' => 'French',
+            '1.2' => 'English',
+            '1.10' => 'Japanese',
+            '1.20' => 'Chinese',
+        ]);
+        $select->setValue(['1.1']);
+        $this->assertEquals(['1.1'], $select->getValue());
+
+        $markup  = $this->helper->render($select);
+
+        $this->assertMatchesRegularExpression('{value="1.1" selected="selected"}i', $markup);
+        $this->assertDoesNotMatchRegularExpression('{value="1.2" selected="selected"}i', $markup);
+        $this->assertDoesNotMatchRegularExpression('{value="1.10" selected="selected"}i', $markup);
+        $this->assertDoesNotMatchRegularExpression('{value="1.20" selected="selected"}i', $markup);
+    }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | yes
| New Feature   | no
| RFC           | no
| QA            | no

### Description

This MR fixes #52 (and zendframework/zend-form#18) by adding the test case provided in #52 and an implementation to let that test pass.

I would consider this a BC break since as people who might have relied on the currently implemented weak comparison in v2.x might be affected by this change. However, that will probably be an edge case.
