### PR TITLE
Elements MonthSelect, DateSelect and DateTimeSelect differentiating between null and empty strings (issue 54)

### DIFF
--- a/src/Element/DateSelect.php
+++ b/src/Element/DateSelect.php
@@ -13,6 +13,7 @@ use Laminas\Validator\Date as DateValidator;
 use Laminas\Validator\ValidatorInterface;
 
 use function array_merge;
+use function is_array;
 use function is_string;
 use function sprintf;
 
@@ -107,7 +108,7 @@ class DateSelect extends MonthSelect
             }
         }
 
-        if (null === $value && !$this->shouldCreateEmptyOption()) {
+        if (null === $value && ! $this->shouldCreateEmptyOption()) {
             $value = new PhpDateTime();
         }
 
@@ -134,9 +135,9 @@ class DateSelect extends MonthSelect
 
     public function getValue(): string
     {
-        $year = $this->getYearElement()->getValue();
+        $year  = $this->getYearElement()->getValue();
         $month = $this->getMonthElement()->getValue();
-        $day = $this->getDayElement()->getValue();
+        $day   = $this->getDayElement()->getValue();
 
         if ($this->shouldCreateEmptyOption() && null === $year && null === $month && null === $day) {
             return null;

--- a/src/Element/DateSelect.php
+++ b/src/Element/DateSelect.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Laminas\Form\Element;
 
-use ArrayAccess;
 use DateTime as PhpDateTime;
 use Exception;
 use Laminas\Form\Exception\InvalidArgumentException;
@@ -94,8 +93,8 @@ class DateSelect extends MonthSelect
     }
 
     /**
-     * @param  string|array|ArrayAccess|PhpDateTime|null $value
-     * @return $this Provides a fluent interface
+     * @param  PhpDateTime|iterable|string|null|mixed $value
+     * @return $this
      * @throws InvalidArgumentException
      */
     public function setValue($value)
@@ -133,7 +132,7 @@ class DateSelect extends MonthSelect
         return $this;
     }
 
-    public function getValue(): string
+    public function getValue(): ?string
     {
         $year  = $this->getYearElement()->getValue();
         $month = $this->getMonthElement()->getValue();

--- a/src/Element/DateSelect.php
+++ b/src/Element/DateSelect.php
@@ -93,7 +93,7 @@ class DateSelect extends MonthSelect
     }
 
     /**
-     * @param  string|array|ArrayAccess|PhpDateTime $value
+     * @param  string|array|ArrayAccess|PhpDateTime|null $value
      * @return $this Provides a fluent interface
      * @throws InvalidArgumentException
      */
@@ -107,6 +107,10 @@ class DateSelect extends MonthSelect
             }
         }
 
+        if (null === $value && !$this->shouldCreateEmptyOption()) {
+            $value = new PhpDateTime();
+        }
+
         if ($value instanceof PhpDateTime) {
             $value = [
                 'year'  => $value->format('Y'),
@@ -115,21 +119,30 @@ class DateSelect extends MonthSelect
             ];
         }
 
-        $this->yearElement->setValue($value['year']);
-        $this->monthElement->setValue($value['month']);
-        $this->dayElement->setValue($value['day']);
+        if (is_array($value)) {
+            $this->yearElement->setValue($value['year']);
+            $this->monthElement->setValue($value['month']);
+            $this->dayElement->setValue($value['day']);
+        } else {
+            $this->yearElement->setValue(null);
+            $this->monthElement->setValue(null);
+            $this->dayElement->setValue(null);
+        }
 
         return $this;
     }
 
     public function getValue(): string
     {
-        return sprintf(
-            '%s-%s-%s',
-            $this->getYearElement()->getValue(),
-            $this->getMonthElement()->getValue(),
-            $this->getDayElement()->getValue()
-        );
+        $year = $this->getYearElement()->getValue();
+        $month = $this->getMonthElement()->getValue();
+        $day = $this->getDayElement()->getValue();
+
+        if ($this->shouldCreateEmptyOption() && null === $year && null === $month && null === $day) {
+            return null;
+        }
+
+        return sprintf('%s-%s-%s', $year, $month, $day);
     }
 
     /**

--- a/src/Element/DateSelect.php
+++ b/src/Element/DateSelect.php
@@ -142,7 +142,7 @@ class DateSelect extends MonthSelect
             return null;
         }
 
-        return sprintf('%s-%s-%s', $year, $month, $day);
+        return sprintf('%04d-%02d-%02d', $year, $month, $day);
     }
 
     /**

--- a/src/Element/DateTimeSelect.php
+++ b/src/Element/DateTimeSelect.php
@@ -271,7 +271,7 @@ class DateTimeSelect extends DateSelect
             $day   = $now->format('d');
         }
 
-        // if date is give, but time is null, use 00:00:00 instead
+        // if date is given, but time is null, use 00:00:00 instead
         if (
             $this->shouldCreateEmptyOption()
             && null === $hour && null === $minute && (null === $second || '00' === $second)
@@ -282,7 +282,7 @@ class DateTimeSelect extends DateSelect
         }
 
         return sprintf(
-            '%s-%s-%s %s:%s:%s',
+            '%04d-%02d-%02d %02d:%02d:%02d',
             $year,
             $month,
             $day,

--- a/src/Element/DateTimeSelect.php
+++ b/src/Element/DateTimeSelect.php
@@ -194,7 +194,7 @@ class DateTimeSelect extends DateSelect
     }
 
     /**
-     * @param mixed $value
+     * @param  PhpDateTime|iterable|string|null|mixed $value
      * @return $this
      * @throws InvalidArgumentException
      */
@@ -242,7 +242,7 @@ class DateTimeSelect extends DateSelect
         return $this;
     }
 
-    public function getValue(): string
+    public function getValue(): ?string
     {
         $year   = $this->getYearElement()->getValue();
         $month  = $this->getMonthElement()->getValue();

--- a/src/Element/MonthSelect.php
+++ b/src/Element/MonthSelect.php
@@ -251,7 +251,7 @@ class MonthSelect extends Element implements InputProviderInterface, ElementPrep
      */
     public function setValue($value)
     {
-        if (null === $value && !$this->shouldCreateEmptyOption()) {
+        if (null === $value && ! $this->shouldCreateEmptyOption()) {
             $value = new PhpDateTime();
         }
 
@@ -275,7 +275,7 @@ class MonthSelect extends Element implements InputProviderInterface, ElementPrep
 
     public function getValue(): string
     {
-        $year = $this->getYearElement()->getValue();
+        $year  = $this->getYearElement()->getValue();
         $month = $this->getMonthElement()->getValue();
 
         if ($this->shouldCreateEmptyOption() && null === $year && null === $month) {

--- a/src/Element/MonthSelect.php
+++ b/src/Element/MonthSelect.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Laminas\Form\Element;
 
 use DateTime as PhpDateTime;
+use Exception;
 use Laminas\Form\Element;
 use Laminas\Form\ElementPrepareAwareInterface;
+use Laminas\Form\Exception\InvalidArgumentException;
 use Laminas\Form\FormInterface;
 use Laminas\InputFilter\InputProviderInterface;
 use Laminas\Validator\Regex as RegexValidator;
@@ -14,6 +16,7 @@ use Laminas\Validator\ValidatorInterface;
 
 use function date;
 use function is_array;
+use function is_string;
 use function sprintf;
 
 class MonthSelect extends Element implements InputProviderInterface, ElementPrepareAwareInterface
@@ -246,11 +249,19 @@ class MonthSelect extends Element implements InputProviderInterface, ElementPrep
     }
 
     /**
-     * @param mixed $value
+     * @param  PhpDateTime|iterable|string|null|mixed $value
      * @return $this
      */
     public function setValue($value)
     {
+        if (is_string($value)) {
+            try {
+                $value = new PhpDateTime($value);
+            } catch (Exception $e) {
+                throw new InvalidArgumentException('Value should be a parsable string or an instance of \DateTime');
+            }
+        }
+
         if (null === $value && ! $this->shouldCreateEmptyOption()) {
             $value = new PhpDateTime();
         }
@@ -273,7 +284,7 @@ class MonthSelect extends Element implements InputProviderInterface, ElementPrep
         return $this;
     }
 
-    public function getValue(): string
+    public function getValue(): ?string
     {
         $year  = $this->getYearElement()->getValue();
         $month = $this->getMonthElement()->getValue();

--- a/src/Element/MonthSelect.php
+++ b/src/Element/MonthSelect.php
@@ -13,6 +13,7 @@ use Laminas\Validator\Regex as RegexValidator;
 use Laminas\Validator\ValidatorInterface;
 
 use function date;
+use function is_array;
 use function sprintf;
 
 class MonthSelect extends Element implements InputProviderInterface, ElementPrepareAwareInterface
@@ -250,6 +251,10 @@ class MonthSelect extends Element implements InputProviderInterface, ElementPrep
      */
     public function setValue($value)
     {
+        if (null === $value && !$this->shouldCreateEmptyOption()) {
+            $value = new PhpDateTime();
+        }
+
         if ($value instanceof PhpDateTime) {
             $value = [
                 'year'  => $value->format('Y'),
@@ -257,13 +262,26 @@ class MonthSelect extends Element implements InputProviderInterface, ElementPrep
             ];
         }
 
-        $this->yearElement->setValue($value['year']);
-        $this->monthElement->setValue($value['month']);
+        if (is_array($value)) {
+            $this->yearElement->setValue($value['year']);
+            $this->monthElement->setValue($value['month']);
+        } else {
+            $this->yearElement->setValue(null);
+            $this->monthElement->setValue(null);
+        }
+
         return $this;
     }
 
     public function getValue(): string
     {
+        $year = $this->getYearElement()->getValue();
+        $month = $this->getMonthElement()->getValue();
+
+        if ($this->shouldCreateEmptyOption() && null === $year && null === $month) {
+            return null;
+        }
+
         return sprintf(
             '%s-%s',
             $this->getYearElement()->getValue(),

--- a/src/Element/MonthSelect.php
+++ b/src/Element/MonthSelect.php
@@ -257,8 +257,12 @@ class MonthSelect extends Element implements InputProviderInterface, ElementPrep
         if (is_string($value)) {
             try {
                 $value = new PhpDateTime($value);
-            } catch (Exception $e) {
-                throw new InvalidArgumentException('Value should be a parsable string or an instance of \DateTime');
+            } catch (Exception $exception) {
+                throw new InvalidArgumentException(
+                    'Value should be a parsable string or an instance of \DateTime',
+                    0,
+                    $exception
+                );
             }
         }
 

--- a/src/Element/MonthSelect.php
+++ b/src/Element/MonthSelect.php
@@ -293,11 +293,7 @@ class MonthSelect extends Element implements InputProviderInterface, ElementPrep
             return null;
         }
 
-        return sprintf(
-            '%s-%s',
-            $this->getYearElement()->getValue(),
-            $this->getMonthElement()->getValue()
-        );
+        return sprintf('%04d-%02d', $year, $month);
     }
 
     /**

--- a/test/Element/DateSelectTest.php
+++ b/test/Element/DateSelectTest.php
@@ -111,21 +111,21 @@ final class DateSelectTest extends TestCase
 
         $this->assertSame($element, $element->setValue('2014-01-01'));
     }
-    
+
     public function testNullSetValueIsSemanticallyTodayWithoutEmptyOption()
     {
-        $element  = new DateSelectElement('foo');
+        $element = new DateSelectElement('foo');
         $element->setShouldCreateEmptyOption(false);
-        $now = new \DateTime();
+        $now = new DateTime();
         $element->setValue(null);
         $value = $element->getValue();
         // the getValue() function returns the date in 'Y-m-d' format
         $this->assertEquals($now->format('Y-m-d'), $value);
     }
-    
+
     public function testNullSetValueIsNullWithEmptyOption()
     {
-        $element  = new DateSelectElement('foo');
+        $element = new DateSelectElement('foo');
         $element->setShouldCreateEmptyOption(true);
         $element->setValue(null);
         $value = $element->getValue();

--- a/test/Element/DateSelectTest.php
+++ b/test/Element/DateSelectTest.php
@@ -111,4 +111,24 @@ final class DateSelectTest extends TestCase
 
         $this->assertSame($element, $element->setValue('2014-01-01'));
     }
+    
+    public function testNullSetValueIsSemanticallyTodayWithoutEmptyOption()
+    {
+        $element  = new DateSelectElement('foo');
+        $element->setShouldCreateEmptyOption(false);
+        $now = new \DateTime();
+        $element->setValue(null);
+        $value = $element->getValue();
+        // the getValue() function returns the date in 'Y-m-d' format
+        $this->assertEquals($now->format('Y-m-d'), $value);
+    }
+    
+    public function testNullSetValueIsNullWithEmptyOption()
+    {
+        $element  = new DateSelectElement('foo');
+        $element->setShouldCreateEmptyOption(true);
+        $element->setValue(null);
+        $value = $element->getValue();
+        $this->assertEquals(null, $value);
+    }
 }

--- a/test/Element/DateSelectTest.php
+++ b/test/Element/DateSelectTest.php
@@ -112,7 +112,7 @@ final class DateSelectTest extends TestCase
         $this->assertSame($element, $element->setValue('2014-01-01'));
     }
 
-    public function testNullSetValueIsSemanticallyTodayWithoutEmptyOption()
+    public function testNullSetValueIsSemanticallyTodayWithoutEmptyOption(): void
     {
         $element = new DateSelectElement('foo');
         $element->setShouldCreateEmptyOption(false);
@@ -123,7 +123,7 @@ final class DateSelectTest extends TestCase
         $this->assertEquals($now->format('Y-m-d'), $value);
     }
 
-    public function testNullSetValueIsNullWithEmptyOption()
+    public function testNullSetValueIsNullWithEmptyOption(): void
     {
         $element = new DateSelectElement('foo');
         $element->setShouldCreateEmptyOption(true);

--- a/test/Element/DateTimeSelectTest.php
+++ b/test/Element/DateTimeSelectTest.php
@@ -133,16 +133,57 @@ final class DateTimeSelectTest extends TestCase
         $this->assertEquals('05', $cloned->getSecondElement()->getValue());
     }
 
-    public function testPassingNullValueToSetValueWillUseCurrentDate(): void
+    public function testNullSetValueIsSemanticallyTodayWithoutEmptyOption(): void
+    {
+        $element = new DateTimeSelectElement('foo');
+        $element->setShouldCreateEmptyOption(false);
+        $now = new DateTime();
+        $element->setValue(null);
+        $value = $element->getValue();
+        // the getValue() function returns the date in 'Y-m-d' format
+        $this->assertEquals($now->format('Y-m-d H:i:s'), $value);
+    }
+
+    public function testNullSetValueIsNullWithEmptyOption(): void
+    {
+        $element = new DateTimeSelectElement('foo');
+        $element->setShouldCreateEmptyOption(true);
+        $element->setValue(null);
+        $value = $element->getValue();
+        $this->assertEquals(null, $value);
+    }
+
+    public function testSettingTimeOnlyUsesCurrentDate(): void
     {
         $now     = new DateTime();
-        $element = new DateTimeSelectElement();
-        $element->setValue(null);
-        $yearElement  = $element->getYearElement();
-        $monthElement = $element->getMonthElement();
-        $dayElement   = $element->getDayElement();
-        $this->assertEquals($now->format('Y'), $yearElement->getValue());
-        $this->assertEquals($now->format('m'), $monthElement->getValue());
-        $this->assertEquals($now->format('d'), $dayElement->getValue());
+        $element = new DateTimeSelectElement('foo');
+        $element->setShouldCreateEmptyOption(true);
+        $element->setValue([
+            'year'   => null,
+            'month'  => null,
+            'day'    => null,
+            'hour'   => $now->format('H'),
+            'minute' => $now->format('i'),
+            'second' => $now->format('s'),
+        ]);
+        $value = $element->getValue();
+        $this->assertEquals($now->format('Y-m-d H:i:s'), $value);
+    }
+
+    public function testSettingDateOnlyUsesMidnightTime(): void
+    {
+        $now     = new DateTime();
+        $element = new DateTimeSelectElement('foo');
+        $element->setShouldCreateEmptyOption(true);
+        $element->setValue([
+            'year'   => $now->format('Y'),
+            'month'  => $now->format('m'),
+            'day'    => $now->format('d'),
+            'hour'   => null,
+            'minute' => null,
+            'second' => null,
+        ]);
+        $value = $element->getValue();
+        $this->assertEquals($now->format('Y-m-d 00:00:00'), $value);
     }
 }

--- a/test/Element/MonthSelectTest.php
+++ b/test/Element/MonthSelectTest.php
@@ -85,7 +85,7 @@ final class MonthSelectTest extends TestCase
         $this->assertEquals('2012-09', $element->getValue());
     }
 
-    public function testNullSetValueIsSemanticallyTodayWithoutEmptyOption()
+    public function testNullSetValueIsSemanticallyTodayWithoutEmptyOption(): void
     {
         $element = new MonthSelectElement('foo');
         $element->setShouldCreateEmptyOption(false);
@@ -96,7 +96,7 @@ final class MonthSelectTest extends TestCase
         $this->assertEquals($now->format('Y-m'), $value);
     }
 
-    public function testNullSetValueIsNullWithEmptyOption()
+    public function testNullSetValueIsNullWithEmptyOption(): void
     {
         $element = new MonthSelectElement('foo');
         $element->setShouldCreateEmptyOption(true);

--- a/test/Element/MonthSelectTest.php
+++ b/test/Element/MonthSelectTest.php
@@ -84,4 +84,24 @@ final class MonthSelectTest extends TestCase
         $element->setValue(new DateTime('2012-09'));
         $this->assertEquals('2012-09', $element->getValue());
     }
+
+    public function testNullSetValueIsSemanticallyTodayWithoutEmptyOption()
+    {
+        $element  = new MonthSelectElement('foo');
+        $element->setShouldCreateEmptyOption(false);
+        $now = new \DateTime();
+        $element->setValue(null);
+        $value = $element->getValue();
+        // the getValue() function returns the date in 'Y-m-d' format
+        $this->assertEquals($now->format('Y-m'), $value);
+    }
+
+    public function testNullSetValueIsNullWithEmptyOption()
+    {
+        $element  = new MonthSelectElement('foo');
+        $element->setShouldCreateEmptyOption(true);
+        $element->setValue(null);
+        $value = $element->getValue();
+        $this->assertEquals(null, $value);
+    }
 }

--- a/test/Element/MonthSelectTest.php
+++ b/test/Element/MonthSelectTest.php
@@ -87,9 +87,9 @@ final class MonthSelectTest extends TestCase
 
     public function testNullSetValueIsSemanticallyTodayWithoutEmptyOption()
     {
-        $element  = new MonthSelectElement('foo');
+        $element = new MonthSelectElement('foo');
         $element->setShouldCreateEmptyOption(false);
-        $now = new \DateTime();
+        $now = new DateTime();
         $element->setValue(null);
         $value = $element->getValue();
         // the getValue() function returns the date in 'Y-m-d' format
@@ -98,7 +98,7 @@ final class MonthSelectTest extends TestCase
 
     public function testNullSetValueIsNullWithEmptyOption()
     {
-        $element  = new MonthSelectElement('foo');
+        $element = new MonthSelectElement('foo');
         $element->setShouldCreateEmptyOption(true);
         $element->setValue(null);
         $value = $element->getValue();


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | yes
| New Feature   | yes
| RFC           | yes
| QA            | no

### Description

This MR picks up the unit tests provided in MR #70 and fixes issue #54.

First, this MR prevents the PHP Notices `Trying to access array offset on value of type null` mentioned in #54, which should be considered a bugfix. 

Next, this MR aligns the behaviour of MonthSelect, DateSelect and DateTimeSelect. Previously, only DateTimeSelect had an explicit check for `null` values and handled such by using a current timestamp. Since DateTimeSelect has been aligned with the two other (that had a consistent behaviour anyways), the change für DateTimeSelect needs to be considered as a BC break.

Lastly, this MR provides a new feature for `DateTimeSelect`. The current behaviour was to return a crazy mixture of fields that have been set and fields that have not been set. For instance, when `createEmptyOption` was enabled, then `getValue()` could return something like `2021-05-25 ::`. Now, if the date is all null it will be replaced with the current date and if the time is all null it will become `00:00:00`.

Potentially, this could be evolved further for MonthSelect and DateSelect, so that `2021--` would become `2021-00-00`. The latter would at least syntactically what one would excpect to get from `getValue()`. This is how it could look like:

```php
    public function getValue()
    {
        $year = $this->getYearElement()->getValue();
        $month = $this->getMonthElement()->getValue();
        $day = $this->getDayElement()->getValue();

        if ($this->shouldCreateEmptyOption() && null === $year && null === $month && null === $day) {
            return null;
        }

        return sprintf(
            '%04d-%02d-%02d', 
            $year,
            $month,
            $day
        );
    }
```