### PR TITLE
FormElementManager: revert final, keep it extensible

### DIFF
--- a/src/FormElementManager.php
+++ b/src/FormElementManager.php
@@ -24,7 +24,7 @@ use function sprintf;
  *
  * Enforces that elements retrieved are instances of ElementInterface.
  */
-final class FormElementManager extends AbstractPluginManager
+class FormElementManager extends AbstractPluginManager
 {
     /**
      * Aliases for default set of helpers


### PR DESCRIPTION
Partial revert on #137: `FormElementManager` may be type-hinted on many placed due to its methods not present in its interfaces.