### PR TITLE
Move FormInterface::setValidationGroup(FormInterface::VALIDATE_ALL) to FormInterface::setValidateAll()

### DIFF
--- a/docs/book/v3/migration/v2-to-v3.md
+++ b/docs/book/v3/migration/v2-to-v3.md
@@ -16,6 +16,13 @@ can help you with this command:
 $ php-cs-fixer fix --rules=phpdoc_to_param_type,phpdoc_to_return_type --allow-risky=yes path/to/my/custom/forms/
 ```
 
+## API changes
+
+Many notable API have been changed:
+
+- `\Laminas\Form\FormInterface::setValidationGroup(FormInterface::VALIDATE_ALL)` has now its own dedicated method
+  `\Laminas\Form\FormInterface::setValidateAll()`
+
 ## Using doctrine/annotations now instead of laminas/laminas-code
 
 Since laminas-code dropped support for annotation parsing with v4, laminas-form

--- a/docs/book/v3/quick-start.md
+++ b/docs/book/v3/quick-start.md
@@ -555,7 +555,7 @@ laminas-form provides a proxy method to the underlying `InputFilter`'s
 `setValidationGroup()` method, allowing us to perform this operation.
 
 ```php
-$form->setValidationGroup('name', 'email', 'subject', 'message');
+$form->setValidationGroup(['name', 'email', 'subject', 'message']);
 $form->setData($data);
 if ($form->isValid()) {
     // Contains only the "name", "email", "subject", and "message" values
@@ -563,12 +563,12 @@ if ($form->isValid()) {
 }
 ```
 
-If you later want to reset the form to validate all elements, pass the
-`FormInterface::VALIDATE_ALL` flag to the `setValidationGroup()` method:
+If you later want to reset the form to validate all elements, call the
+`FormInterface::setValidateAll()` method:
 
 ```php
 use Laminas\Form\FormInterface;
-$form->setValidationGroup(FormInterface::VALIDATE_ALL);
+$form->setValidateAll();
 ```
 
 When your form contains nested fieldsets, you can use an array notation to

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -276,7 +276,7 @@ class Factory
         }
 
         if (isset($spec['validation_group'])) {
-            $this->prepareAndInjectValidationGroup($spec['validation_group'], $form, __METHOD__);
+            $form->setValidationGroup($spec['validation_group']);
         }
 
         return $form;
@@ -513,28 +513,5 @@ class Factory
             $filter->setFactory($factory);
         }
         $form->setInputFilter($filter);
-    }
-
-    /**
-     * Prepare a validation group and inject in the provided form
-     *
-     * Takes an array of elements names
-     *
-     * @param  class-string|array $spec
-     * @throws Exception\DomainException If validation group given is not an array.
-     */
-    protected function prepareAndInjectValidationGroup($spec, FormInterface $form, string $method): void
-    {
-        if (! is_array($spec)) {
-            if (! class_exists($spec)) {
-                throw new Exception\DomainException(sprintf(
-                    '%s expects an array for validation group; received "%s"',
-                    $method,
-                    is_object($spec) ? get_class($spec) : gettype($spec)
-                ));
-            }
-        }
-
-        $form->setValidationGroup($spec);
     }
 }

--- a/src/Form.php
+++ b/src/Form.php
@@ -18,10 +18,7 @@ use Traversable;
 
 use function array_key_exists;
 use function array_keys;
-use function array_shift;
 use function assert;
-use function func_get_args;
-use function func_num_args;
 use function in_array;
 use function is_array;
 use function is_object;
@@ -531,39 +528,19 @@ class Form extends Fieldset implements FormInterface
      *
      * Typically, proxies to the composed input filter
      *
-     * @throws Exception\InvalidArgumentException
      * @return $this
      */
-    public function setValidationGroup()
+    public function setValidationGroup(array $group)
     {
-        $argc = func_num_args();
-        if (0 === $argc) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s expects at least one argument; none provided',
-                __METHOD__
-            ));
-        }
-
-        $argv               = func_get_args();
-        $this->hasValidated = false;
-
-        if ($argc > 1) {
-            $this->validationGroup = $argv;
-            return $this;
-        }
-
-        $arg = array_shift($argv);
-        if ($arg === FormInterface::VALIDATE_ALL) {
-            $this->validationGroup = null;
-            return $this;
-        }
-
-        if (! is_array($arg)) {
-            $arg = (array) $arg;
-        }
-
-        $this->validationGroup = $arg;
+        $this->hasValidated    = false;
+        $this->validationGroup = $group;
         return $this;
+    }
+
+    public function setValidateAll(): void
+    {
+        $this->hasValidated    = false;
+        $this->validationGroup = null;
     }
 
     /**

--- a/src/FormInterface.php
+++ b/src/FormInterface.php
@@ -10,7 +10,6 @@ interface FormInterface extends FieldsetInterface
 {
     public const BIND_ON_VALIDATE  = 0x00;
     public const BIND_MANUAL       = 0x01;
-    public const VALIDATE_ALL      = 0x10;
     public const VALUES_NORMALIZED = 0x11;
     public const VALUES_RAW        = 0x12;
     public const VALUES_AS_ARRAY   = 0x13;
@@ -76,5 +75,10 @@ interface FormInterface extends FieldsetInterface
      *
      * @return $this
      */
-    public function setValidationGroup();
+    public function setValidationGroup(array $group);
+
+    /**
+     * Reset the form to validate all elements
+     */
+    public function setValidateAll(): void;
 }

--- a/test/FormTest.php
+++ b/test/FormTest.php
@@ -267,7 +267,7 @@ final class FormTest extends TestCase
         $invalidSet = [
             'foo' => 'a',
         ];
-        $this->form->setValidationGroup('foo');
+        $this->form->setValidationGroup(['foo']);
         $this->form->setData($invalidSet);
         $this->assertFalse($this->form->isValid());
 
@@ -306,22 +306,16 @@ final class FormTest extends TestCase
     public function testSettingValidateAllFlagAfterPartialValidationForcesFullValidation(): void
     {
         $this->populateForm();
-        $this->form->setValidationGroup('foo');
+        $this->form->setValidationGroup(['foo']);
 
         $validSet = [
             'foo' => 'abcde',
         ];
         $this->form->setData($validSet);
-        $this->form->setValidationGroup(Form::VALIDATE_ALL);
+        $this->form->setValidateAll();
         $this->assertFalse($this->form->isValid());
         $messages = $this->form->getMessages();
         $this->assertArrayHasKey('foobar', $messages, var_export($messages, true));
-    }
-
-    public function testSetValidationGroupWithNoArgumentsRaisesException(): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->form->setValidationGroup();
     }
 
     public function testCallingGetDataPriorToValidationRaisesException(): void
@@ -538,7 +532,7 @@ final class FormTest extends TestCase
             ],
         ];
         $this->populateForm();
-        $this->form->setValidationGroup('foo');
+        $this->form->setValidationGroup(['foo']);
         $this->form->setData($validSet);
         $this->form->isValid();
         $data = $this->form->getData();
@@ -563,7 +557,7 @@ final class FormTest extends TestCase
         $this->form->setHydrator(new ObjectPropertyHydrator());
         $this->form->bind($model);
         $this->form->setData($validSet);
-        $this->form->setValidationGroup('foo');
+        $this->form->setValidationGroup(['foo']);
         $this->form->isValid();
 
         $this->assertObjectHasAttribute('foo', $model);


### PR DESCRIPTION
This simplifies a lot the code, lets us add native types and remove `func_get_args` burden.