### PR TITLE
Limit type of fieldset/element constructor

### DIFF
--- a/src/Element.php
+++ b/src/Element.php
@@ -46,7 +46,7 @@ class Element implements
     protected $hasValue = false;
 
     /**
-     * @param  null|string   $name    Optional name for the element
+     * @param  null|int|string $name Optional name for the element
      * @param  iterable $options Optional options for the element
      * @throws Exception\InvalidArgumentException
      */

--- a/src/Element.php
+++ b/src/Element.php
@@ -46,7 +46,7 @@ class Element implements
     protected $hasValue = false;
 
     /**
-     * @param  null|int|string $name Optional name for the element
+     * @param  null|string $name Optional name for the element
      * @param  iterable $options Optional options for the element
      * @throws Exception\InvalidArgumentException
      */

--- a/src/Element.php
+++ b/src/Element.php
@@ -46,11 +46,11 @@ class Element implements
     protected $hasValue = false;
 
     /**
-     * @param  null|int|string   $name    Optional name for the element
+     * @param  null|string   $name    Optional name for the element
      * @param  iterable $options Optional options for the element
      * @throws Exception\InvalidArgumentException
      */
-    public function __construct($name = null, iterable $options = [])
+    public function __construct(?string $name = null, iterable $options = [])
     {
         if (null !== $name) {
             $this->setName((string) $name);

--- a/src/Element.php
+++ b/src/Element.php
@@ -46,11 +46,11 @@ class Element implements
     protected $hasValue = false;
 
     /**
-     * @param  null|string $name Optional name for the element
+     * @param  null|int|string $name Optional name for the element
      * @param  iterable $options Optional options for the element
      * @throws Exception\InvalidArgumentException
      */
-    public function __construct(?string $name = null, iterable $options = [])
+    public function __construct($name = null, iterable $options = [])
     {
         if (null !== $name) {
             $this->setName((string) $name);

--- a/src/Fieldset.php
+++ b/src/Fieldset.php
@@ -69,10 +69,10 @@ class Fieldset extends Element implements FieldsetInterface
     protected $allowedObjectBindingClass;
 
     /**
-     * @param  null|int|string  $name    Optional name for the element
-     * @param  array            $options Optional options for the element
+     * @param  null|string  $name    Optional name for the element
+     * @param  array        $options Optional options for the element
      */
-    public function __construct($name = null, array $options = [])
+    public function __construct(?string $name = null, array $options = [])
     {
         $this->iterator = new PriorityList();
         $this->iterator->isLIFO(false);

--- a/src/Fieldset.php
+++ b/src/Fieldset.php
@@ -191,8 +191,17 @@ class Fieldset extends Element implements FieldsetInterface
     /**
      * Does the fieldset have an element/fieldset by the given name?
      */
-    public function has(string $elementOrFieldset): bool
+    public function has($elementOrFieldset): bool
     {
+        if (! is_string($elementOrFieldset)) {
+            throw new Exception\InvalidElementException(
+                sprintf(
+                    'Name of element or fieldset should be string, [%s] provided, consider typecasting to string',
+                    gettype($elementOrFieldset)
+                )
+            );
+        }
+
         return $this->iterator->get($elementOrFieldset) !== null;
     }
 
@@ -201,8 +210,17 @@ class Fieldset extends Element implements FieldsetInterface
      *
      * @return FieldsetInterface|ElementInterface
      */
-    public function get(string $elementOrFieldset): ElementInterface
+    public function get($elementOrFieldset): ElementInterface
     {
+        if (! is_string($elementOrFieldset)) {
+            throw new Exception\InvalidElementException(
+                sprintf(
+                    'Name of element or fieldset should be string,  [%s] provided, consider typecasting to string',
+                    gettype($elementOrFieldset)
+                )
+            );
+        }
+
         if (! $this->has($elementOrFieldset)) {
             throw new Exception\InvalidElementException(sprintf(
                 'No element by the name of [%s] found in form',
@@ -217,8 +235,17 @@ class Fieldset extends Element implements FieldsetInterface
      *
      * @return $this
      */
-    public function remove(string $elementOrFieldset)
+    public function remove($elementOrFieldset)
     {
+        if (! is_string($elementOrFieldset)) {
+            throw new Exception\InvalidElementException(
+                sprintf(
+                    'Name of element or fieldset should be string,  [%s] provided, consider typecasting to string',
+                    gettype($elementOrFieldset)
+                )
+            );
+        }
+
         if (! $this->has($elementOrFieldset)) {
             return $this;
         }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes/no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

In Laminas Form v3 the \Laminas\Form\Fieldset->get() function requires a (string), this means that fieldsets can only have a string typed name. In V2 it was possible to use just an integer so the upgrade to V3 broke the code, but just at the retrieval of the fietset. 

The constructor of the fieldset (the formelement) casts the name to a string using setName but this moves the error to the getter which the results in an error you want to do $fiedset->get(1)

In this PR is narrowed the allowed types in the fieldset and element constructor to a nullable string, but maybe is ```string $name = null``` also fine, but I kept the null|string limitation so passing null should also be possible

This might break code like the string constraint on the getter but now on an earlier phase
