### PR TITLE
Allow override of CSRF name

### DIFF
--- a/src/Element/Csrf.php
+++ b/src/Element/Csrf.php
@@ -73,7 +73,7 @@ class Csrf extends Element implements InputProviderInterface, ElementPrepareAwar
     {
         if (null === $this->csrfValidator) {
             $csrfOptions = $this->getCsrfValidatorOptions();
-            $csrfOptions = array_merge($csrfOptions, ['name' => $this->getName()]);
+            $csrfOptions = array_merge(['name' => $this->getName()], $csrfOptions);
             $this->setCsrfValidator(new CsrfValidator($csrfOptions));
             assert(null !== $this->csrfValidator);
         }

--- a/test/Element/CsrfTest.php
+++ b/test/Element/CsrfTest.php
@@ -83,4 +83,18 @@ final class CsrfTest extends TestCase
         $this->assertEquals(777, $validator->getTimeOut());
         $this->assertEquals('MySalt', $validator->getSalt());
     }
+
+    public function testNameOverride(): void
+    {
+        $element = new CsrfElement('foo');
+        $element->setOptions([
+            'csrf_options' => [
+                'name' => 'bar',
+            ],
+        ]);
+        $validator = $element->getCsrfValidator();
+        $this->assertEquals('foo', $element->getName());
+        $this->assertEquals('bar', $validator->getName());
+        $this->assertEquals('Laminas_Validator_Csrf_salt_bar', $validator->getSessionName());
+    }
 }


### PR DESCRIPTION
Allows the `csrf_options.name` option passed to a `Csrf` element to override the element's own name for the validator, instead of discarding the option entirely.

Fixes #169.

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no¹
| New Feature   | no
| RFC           | no
| QA            | no

¹ Technically yes for people who had the name CSRF option specified before (previously a no-op).