### PR TITLE
Fixes Test Failures relating to InputFilter Regression and Doctrine Annotations Changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "require": {
         "php": "^7.4 || ~8.0.0 || ~8.1.0",
         "laminas/laminas-hydrator": "^4.3.1",
-        "laminas/laminas-inputfilter": "^2.13.0",
+        "laminas/laminas-inputfilter": "^2.19.1",
         "laminas/laminas-stdlib": "^3.7.1"
     },
     "conflict": {
@@ -34,7 +34,7 @@
         "laminas/laminas-i18n": "^2.14.0",
         "laminas/laminas-modulemanager": "^2.11.0",
         "laminas/laminas-recaptcha": "^3.4.0",
-        "laminas/laminas-servicemanager": "^3.10.0",
+        "laminas/laminas-servicemanager": "^3.15.1",
         "laminas/laminas-session": "^2.12.1",
         "laminas/laminas-text": "^2.9.0",
         "laminas/laminas-validator": "^2.16.0",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require-dev": {
         "ext-intl": "*",
-        "doctrine/annotations": "^1.13.2",
+        "doctrine/annotations": "^1.13.3",
         "laminas/laminas-captcha": "^2.11.0",
         "laminas/laminas-coding-standard": "^2.3.0",
         "laminas/laminas-db": "^2.13.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "963c67ebd2e2fb4c8e185ddbc4ea14b4",
+    "content-hash": "4f01b05d2599142db421356c57fc6a32",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -1312,16 +1312,16 @@
         },
         {
             "name": "doctrine/annotations",
-            "version": "1.13.2",
+            "version": "1.13.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/annotations.git",
-                "reference": "5b668aef16090008790395c02c893b1ba13f7e08"
+                "reference": "648b0343343565c4a056bfc8392201385e8d89f0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/annotations/zipball/5b668aef16090008790395c02c893b1ba13f7e08",
-                "reference": "5b668aef16090008790395c02c893b1ba13f7e08",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/648b0343343565c4a056bfc8392201385e8d89f0",
+                "reference": "648b0343343565c4a056bfc8392201385e8d89f0",
                 "shasum": ""
             },
             "require": {
@@ -1333,9 +1333,10 @@
             "require-dev": {
                 "doctrine/cache": "^1.11 || ^2.0",
                 "doctrine/coding-standard": "^6.0 || ^8.1",
-                "phpstan/phpstan": "^0.12.20",
+                "phpstan/phpstan": "^1.4.10 || ^1.8.0",
                 "phpunit/phpunit": "^7.5 || ^8.0 || ^9.1.5",
-                "symfony/cache": "^4.4 || ^5.2"
+                "symfony/cache": "^4.4 || ^5.2",
+                "vimeo/psalm": "^4.10"
             },
             "type": "library",
             "autoload": {
@@ -1378,9 +1379,9 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/annotations/issues",
-                "source": "https://github.com/doctrine/annotations/tree/1.13.2"
+                "source": "https://github.com/doctrine/annotations/tree/1.13.3"
             },
-            "time": "2021-08-05T19:00:23+00:00"
+            "time": "2022-07-02T10:48:51+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -6188,5 +6189,5 @@
     "platform-overrides": {
         "php": "7.4.99"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,44 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4f01b05d2599142db421356c57fc6a32",
+    "content-hash": "947f03491ce796b7b2534403c2477d24",
     "packages": [
-        {
-            "name": "container-interop/container-interop",
-            "version": "1.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/container-interop/container-interop.git",
-                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/container-interop/container-interop/zipball/79cbf1341c22ec75643d841642dd5d6acd83bdb8",
-                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8",
-                "shasum": ""
-            },
-            "require": {
-                "psr/container": "^1.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Interop\\Container\\": "src/Interop/Container/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
-            "homepage": "https://github.com/container-interop/container-interop",
-            "support": {
-                "issues": "https://github.com/container-interop/container-interop/issues",
-                "source": "https://github.com/container-interop/container-interop/tree/master"
-            },
-            "abandoned": "psr/container",
-            "time": "2017-02-14T19:40:03+00:00"
-        },
         {
             "name": "laminas/laminas-filter",
             "version": "2.14.0",
@@ -200,21 +164,21 @@
         },
         {
             "name": "laminas/laminas-inputfilter",
-            "version": "2.13.0",
+            "version": "2.19.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-inputfilter.git",
-                "reference": "6124b3678051b792d1444be689cf9370531593a6"
+                "reference": "864a98cd869fc732274e0045eff63f5775d3f107"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-inputfilter/zipball/6124b3678051b792d1444be689cf9370531593a6",
-                "reference": "6124b3678051b792d1444be689cf9370531593a6",
+                "url": "https://api.github.com/repos/laminas/laminas-inputfilter/zipball/864a98cd869fc732274e0045eff63f5775d3f107",
+                "reference": "864a98cd869fc732274e0045eff63f5775d3f107",
                 "shasum": ""
             },
             "require": {
                 "laminas/laminas-filter": "^2.13",
-                "laminas/laminas-servicemanager": "^3.3.1",
+                "laminas/laminas-servicemanager": "^3.12.0",
                 "laminas/laminas-stdlib": "^3.0",
                 "laminas/laminas-validator": "^2.15",
                 "php": "^7.4 || ~8.0.0 || ~8.1.0"
@@ -223,14 +187,12 @@
                 "zendframework/zend-inputfilter": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~2.2.1",
+                "laminas/laminas-coding-standard": "~2.3.0",
                 "laminas/laminas-db": "^2.13.4",
-                "phpspec/prophecy": "^1.14",
-                "phpspec/prophecy-phpunit": "^2.0",
-                "phpunit/phpunit": "^9.5.5",
-                "psalm/plugin-phpunit": "^0.15.1",
+                "phpunit/phpunit": "^9.5.21",
+                "psalm/plugin-phpunit": "^0.17.0",
                 "psr/http-message": "^1.0",
-                "vimeo/psalm": "^4.6"
+                "vimeo/psalm": "^4.24.0"
             },
             "suggest": {
                 "psr/http-message-implementation": "PSR-7 is required if you wish to validate PSR-7 UploadedFileInterface payloads"
@@ -271,48 +233,50 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-12-02T14:46:43+00:00"
+            "time": "2022-07-25T15:08:16+00:00"
         },
         {
             "name": "laminas/laminas-servicemanager",
-            "version": "3.10.0",
+            "version": "3.15.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-servicemanager.git",
-                "reference": "e52b985909e0940bf22d34f322eb3f48bbef6bd1"
+                "reference": "216f972b179191b14c33a79337947b63bf7808ff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/e52b985909e0940bf22d34f322eb3f48bbef6bd1",
-                "reference": "e52b985909e0940bf22d34f322eb3f48bbef6bd1",
+                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/216f972b179191b14c33a79337947b63bf7808ff",
+                "reference": "216f972b179191b14c33a79337947b63bf7808ff",
                 "shasum": ""
             },
             "require": {
-                "container-interop/container-interop": "^1.2",
                 "laminas/laminas-stdlib": "^3.2.1",
                 "php": "~7.4.0 || ~8.0.0 || ~8.1.0",
                 "psr/container": "^1.0"
             },
             "conflict": {
+                "ext-psr": "*",
                 "laminas/laminas-code": "<3.3.1",
                 "zendframework/zend-code": "<3.3.1",
                 "zendframework/zend-servicemanager": "*"
             },
             "provide": {
-                "container-interop/container-interop-implementation": "^1.2",
                 "psr/container-implementation": "^1.0"
+            },
+            "replace": {
+                "container-interop/container-interop": "^1.2.0"
             },
             "require-dev": {
                 "composer/package-versions-deprecated": "^1.0",
-                "laminas/laminas-coding-standard": "~2.2.1",
-                "laminas/laminas-container-config-test": "^0.3",
+                "laminas/laminas-coding-standard": "~2.3.0",
+                "laminas/laminas-container-config-test": "^0.6",
                 "laminas/laminas-dependency-plugin": "^2.1.2",
                 "mikey179/vfsstream": "^1.6.10@alpha",
                 "ocramius/proxy-manager": "^2.11",
                 "phpbench/phpbench": "^1.1",
                 "phpspec/prophecy-phpunit": "^2.0",
                 "phpunit/phpunit": "^9.5.5",
-                "psalm/plugin-phpunit": "^0.16.1",
+                "psalm/plugin-phpunit": "^0.17.0",
                 "vimeo/psalm": "^4.8"
             },
             "suggest": {
@@ -324,6 +288,9 @@
             ],
             "type": "library",
             "autoload": {
+                "files": [
+                    "src/autoload.php"
+                ],
                 "psr-4": {
                     "Laminas\\ServiceManager\\": "src/"
                 }
@@ -357,7 +324,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-09-18T20:19:36+00:00"
+            "time": "2022-07-20T09:48:45+00:00"
         },
         {
             "name": "laminas/laminas-stdlib",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -9,7 +9,7 @@
     <arg name="parallel" value="80"/>
 
     <!-- Show progress -->
-    <arg value="p"/>
+    <arg value="ps"/>
 
     <!-- Paths to check -->
     <file>src</file>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -26,11 +26,6 @@
       <code>getAttributes</code>
     </UndefinedMethod>
   </file>
-  <file src="src/Annotation/Attributes.php">
-    <UndefinedAttributeClass occurrences="1">
-      <code>Attribute</code>
-    </UndefinedAttributeClass>
-  </file>
   <file src="src/Annotation/BuilderAbstractFactory.php">
     <InvalidStringClass occurrences="1">
       <code>new $requestedName()</code>
@@ -76,13 +71,26 @@
       <code>$this</code>
     </LessSpecificReturnStatement>
   </file>
+  <file src="src/Element/AbstractDateTime.php">
+    <LessSpecificImplementedReturnType occurrences="1">
+      <code>array</code>
+    </LessSpecificImplementedReturnType>
+  </file>
   <file src="src/Element/Captcha.php">
     <DocblockTypeContradiction occurrences="1">
       <code>gettype($captcha)</code>
     </DocblockTypeContradiction>
+    <LessSpecificImplementedReturnType occurrences="1">
+      <code>array</code>
+    </LessSpecificImplementedReturnType>
     <RedundantConditionGivenDocblockType occurrences="1">
       <code>is_object($captcha)</code>
     </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="src/Element/Checkbox.php">
+    <LessSpecificImplementedReturnType occurrences="1">
+      <code>array</code>
+    </LessSpecificImplementedReturnType>
   </file>
   <file src="src/Element/Collection.php">
     <DocblockTypeContradiction occurrences="4">
@@ -113,13 +121,66 @@
       <code>bindValues</code>
     </TooManyArguments>
   </file>
+  <file src="src/Element/Color.php">
+    <LessSpecificImplementedReturnType occurrences="1">
+      <code>array</code>
+    </LessSpecificImplementedReturnType>
+  </file>
+  <file src="src/Element/Csrf.php">
+    <LessSpecificImplementedReturnType occurrences="1">
+      <code>array</code>
+    </LessSpecificImplementedReturnType>
+  </file>
+  <file src="src/Element/DateSelect.php">
+    <LessSpecificImplementedReturnType occurrences="1">
+      <code>array</code>
+    </LessSpecificImplementedReturnType>
+  </file>
+  <file src="src/Element/DateTimeSelect.php">
+    <LessSpecificImplementedReturnType occurrences="1">
+      <code>array</code>
+    </LessSpecificImplementedReturnType>
+  </file>
+  <file src="src/Element/Email.php">
+    <LessSpecificImplementedReturnType occurrences="1">
+      <code>array</code>
+    </LessSpecificImplementedReturnType>
+  </file>
+  <file src="src/Element/File.php">
+    <LessSpecificImplementedReturnType occurrences="1">
+      <code>array</code>
+    </LessSpecificImplementedReturnType>
+  </file>
+  <file src="src/Element/MonthSelect.php">
+    <LessSpecificImplementedReturnType occurrences="1">
+      <code>array</code>
+    </LessSpecificImplementedReturnType>
+  </file>
+  <file src="src/Element/Number.php">
+    <LessSpecificImplementedReturnType occurrences="1">
+      <code>array</code>
+    </LessSpecificImplementedReturnType>
+  </file>
   <file src="src/Element/Select.php">
+    <LessSpecificImplementedReturnType occurrences="1">
+      <code>array</code>
+    </LessSpecificImplementedReturnType>
     <MissingClosureParamType occurrences="1">
       <code>$value</code>
     </MissingClosureParamType>
     <MissingClosureReturnType occurrences="1">
       <code>static function ($value) use ($unselectedValue) {</code>
     </MissingClosureReturnType>
+  </file>
+  <file src="src/Element/Tel.php">
+    <LessSpecificImplementedReturnType occurrences="1">
+      <code>array</code>
+    </LessSpecificImplementedReturnType>
+  </file>
+  <file src="src/Element/Url.php">
+    <LessSpecificImplementedReturnType occurrences="1">
+      <code>array</code>
+    </LessSpecificImplementedReturnType>
   </file>
   <file src="src/ElementFactory.php">
     <InvalidStringClass occurrences="1">
@@ -173,15 +234,19 @@
       <code>$childFieldset</code>
       <code>$filter</code>
     </ArgumentTypeCoercion>
+    <InvalidArgument occurrences="1">
+      <code>$spec</code>
+    </InvalidArgument>
     <LessSpecificReturnStatement occurrences="3">
       <code>$this</code>
       <code>$this</code>
       <code>$this</code>
     </LessSpecificReturnStatement>
-    <PossiblyInvalidArgument occurrences="3">
+    <PossiblyInvalidArgument occurrences="4">
       <code>$collectionInputFilter-&gt;get($name)</code>
       <code>$input</code>
       <code>$inputFilter</code>
+      <code>$spec</code>
     </PossiblyInvalidArgument>
     <PossiblyNullArgument occurrences="1">
       <code>$this-&gt;data</code>
@@ -491,10 +556,10 @@
       <code>$form</code>
     </MissingClosureParamType>
   </file>
-  <file src="test/TestAsset/Annotation/ComplexEntity.php">
-    <DeprecatedClass occurrences="1">
-      <code>Annotation\AllowEmpty()</code>
-    </DeprecatedClass>
+  <file src="test/TestAsset/AddressFieldset.php">
+    <LessSpecificImplementedReturnType occurrences="1">
+      <code>array</code>
+    </LessSpecificImplementedReturnType>
   </file>
   <file src="test/TestAsset/Annotation/InputFilterInput.php">
     <DeprecatedInterface occurrences="1">
@@ -506,11 +571,25 @@
       <code>$username</code>
     </MissingPropertyType>
   </file>
-  <file src="test/TestAsset/Annotation/SampleEntity.php">
-    <DeprecatedClass occurrences="2">
-      <code>Annotation\AllowEmpty(true)</code>
-      <code>Annotation\ContinueIfEmpty(true)</code>
-    </DeprecatedClass>
+  <file src="test/TestAsset/BasicFieldset.php">
+    <LessSpecificImplementedReturnType occurrences="1">
+      <code>array</code>
+    </LessSpecificImplementedReturnType>
+  </file>
+  <file src="test/TestAsset/CategoryFieldset.php">
+    <LessSpecificImplementedReturnType occurrences="1">
+      <code>array</code>
+    </LessSpecificImplementedReturnType>
+  </file>
+  <file src="test/TestAsset/CityFieldset.php">
+    <LessSpecificImplementedReturnType occurrences="1">
+      <code>array</code>
+    </LessSpecificImplementedReturnType>
+  </file>
+  <file src="test/TestAsset/CountryFieldset.php">
+    <LessSpecificImplementedReturnType occurrences="1">
+      <code>array</code>
+    </LessSpecificImplementedReturnType>
   </file>
   <file src="test/TestAsset/CustomCollection.php">
     <PropertyNotSetInConstructor occurrences="1">
@@ -529,6 +608,16 @@
       <code>$this-&gt;view</code>
     </PossiblyNullArgument>
   </file>
+  <file src="test/TestAsset/ElementWithFilter.php">
+    <LessSpecificImplementedReturnType occurrences="1">
+      <code>array</code>
+    </LessSpecificImplementedReturnType>
+  </file>
+  <file src="test/TestAsset/ElementWithStringToArrayFilter.php">
+    <LessSpecificImplementedReturnType occurrences="1">
+      <code>array</code>
+    </LessSpecificImplementedReturnType>
+  </file>
   <file src="test/TestAsset/FieldsetWithDependency.php">
     <MissingParamType occurrences="2">
       <code>$name</code>
@@ -538,7 +627,15 @@
       <code>$dependency</code>
     </PropertyNotSetInConstructor>
   </file>
+  <file src="test/TestAsset/FieldsetWithInputFilter.php">
+    <LessSpecificImplementedReturnType occurrences="1">
+      <code>array[]</code>
+    </LessSpecificImplementedReturnType>
+  </file>
   <file src="test/TestAsset/FileInputFilterProviderFieldset.php">
+    <LessSpecificImplementedReturnType occurrences="1">
+      <code>array[]</code>
+    </LessSpecificImplementedReturnType>
     <MissingParamType occurrences="2">
       <code>$name</code>
       <code>$options</code>
@@ -551,28 +648,55 @@
     </MissingParamType>
   </file>
   <file src="test/TestAsset/InputFilterProvider.php">
+    <LessSpecificImplementedReturnType occurrences="1">
+      <code>array[]</code>
+    </LessSpecificImplementedReturnType>
     <MissingParamType occurrences="2">
       <code>$name</code>
       <code>$options</code>
     </MissingParamType>
   </file>
   <file src="test/TestAsset/InputFilterProviderFieldset.php">
+    <LessSpecificImplementedReturnType occurrences="1">
+      <code>array[]</code>
+    </LessSpecificImplementedReturnType>
     <MissingParamType occurrences="2">
       <code>$name</code>
       <code>$options</code>
     </MissingParamType>
   </file>
   <file src="test/TestAsset/InputFilterProviderWithFieldset.php">
+    <LessSpecificImplementedReturnType occurrences="1">
+      <code>array[]</code>
+    </LessSpecificImplementedReturnType>
     <MissingParamType occurrences="2">
       <code>$name</code>
       <code>$options</code>
     </MissingParamType>
   </file>
+  <file src="test/TestAsset/MyFieldset.php">
+    <LessSpecificImplementedReturnType occurrences="1">
+      <code>array[]</code>
+    </LessSpecificImplementedReturnType>
+  </file>
+  <file src="test/TestAsset/NestedFieldset.php">
+    <LessSpecificImplementedReturnType occurrences="1">
+      <code>array</code>
+    </LessSpecificImplementedReturnType>
+  </file>
   <file src="test/TestAsset/OrphansFieldset.php">
+    <LessSpecificImplementedReturnType occurrences="1">
+      <code>array[]</code>
+    </LessSpecificImplementedReturnType>
     <MissingParamType occurrences="2">
       <code>$name</code>
       <code>$options</code>
     </MissingParamType>
+  </file>
+  <file src="test/TestAsset/ProductFieldset.php">
+    <LessSpecificImplementedReturnType occurrences="1">
+      <code>array</code>
+    </LessSpecificImplementedReturnType>
   </file>
   <file src="test/TestAsset/ValueStoringFieldset.php">
     <PropertyNotSetInConstructor occurrences="1">

--- a/src/Annotation/BuilderAbstractFactory.php
+++ b/src/Annotation/BuilderAbstractFactory.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\Form\Annotation;
 
-use Interop\Container\ContainerInterface;
+use Interop\Container\ContainerInterface; // phpcs:disable WebimpressCodingStandard.PHP.CorrectClassNameCase
 use Laminas\EventManager\EventManagerInterface;
 use Laminas\EventManager\ListenerAggregateInterface;
 use Laminas\Form\Factory;

--- a/src/ElementFactory.php
+++ b/src/ElementFactory.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\Form;
 
-use Interop\Container\ContainerInterface;
+use Interop\Container\ContainerInterface; // phpcs:disable WebimpressCodingStandard.PHP.CorrectClassNameCase
 use Laminas\ServiceManager\Factory\FactoryInterface;
 
 use function array_pop;

--- a/src/FormAbstractServiceFactory.php
+++ b/src/FormAbstractServiceFactory.php
@@ -7,7 +7,9 @@ namespace Laminas\Form;
 use Interop\Container\ContainerInterface; // phpcs:disable WebimpressCodingStandard.PHP.CorrectClassNameCase
 use Laminas\Filter\FilterPluginManager;
 use Laminas\InputFilter\InputFilterInterface;
+use Laminas\InputFilter\InputFilterPluginManager;
 use Laminas\ServiceManager\Factory\AbstractFactoryInterface;
+use Laminas\Validator\ValidatorPluginManager;
 
 use function is_array;
 use function is_string;
@@ -102,8 +104,8 @@ final class FormAbstractServiceFactory implements AbstractFactoryInterface
         }
 
         $elements = null;
-        if ($container->has('FormElementManager')) {
-            $elements = $container->get('FormElementManager');
+        if ($container->has(FormElementManager::class)) {
+            $elements = $container->get(FormElementManager::class);
         }
 
         $this->factory = new Factory($elements);
@@ -133,9 +135,9 @@ final class FormAbstractServiceFactory implements AbstractFactoryInterface
 
         if (
             is_string($config['input_filter'])
-            && $container->has('InputFilterManager')
+            && $container->has(InputFilterPluginManager::class)
         ) {
-            $inputFilters = $container->get('InputFilterManager');
+            $inputFilters = $container->get(InputFilterPluginManager::class);
             if ($inputFilters->has($config['input_filter'])) {
                 $config['input_filter'] = $inputFilters->get($config['input_filter']);
                 return;
@@ -143,7 +145,11 @@ final class FormAbstractServiceFactory implements AbstractFactoryInterface
         }
 
         $inputFilterFactory = $formFactory->getInputFilterFactory();
-        $inputFilterFactory->getDefaultFilterChain()->setPluginManager($container->get('FilterManager'));
-        $inputFilterFactory->getDefaultValidatorChain()->setPluginManager($container->get('ValidatorManager'));
+        $inputFilterFactory->getDefaultFilterChain()->setPluginManager(
+            $container->get(FilterPluginManager::class)
+        );
+        $inputFilterFactory->getDefaultValidatorChain()->setPluginManager(
+            $container->get(ValidatorPluginManager::class)
+        );
     }
 }

--- a/src/FormAbstractServiceFactory.php
+++ b/src/FormAbstractServiceFactory.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace Laminas\Form;
 
-use Interop\Container\ContainerInterface;
+use Interop\Container\ContainerInterface; // phpcs:disable WebimpressCodingStandard.PHP.CorrectClassNameCase
+use Laminas\Filter\FilterPluginManager;
 use Laminas\InputFilter\InputFilterInterface;
 use Laminas\ServiceManager\Factory\AbstractFactoryInterface;
 

--- a/src/FormElementManager.php
+++ b/src/FormElementManager.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\Form;
 
-use Interop\Container\ContainerInterface;
+use Interop\Container\ContainerInterface; // phpcs:disable WebimpressCodingStandard.PHP.CorrectClassNameCase
 use Laminas\Form\Exception;
 use Laminas\ServiceManager\AbstractPluginManager;
 use Laminas\ServiceManager\Exception\InvalidServiceException;

--- a/src/FormElementManagerFactory.php
+++ b/src/FormElementManagerFactory.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\Form;
 
-use Interop\Container\ContainerInterface;
+use Interop\Container\ContainerInterface; // phpcs:disable WebimpressCodingStandard.PHP.CorrectClassNameCase
 use Laminas\ServiceManager\AbstractPluginManager;
 use Laminas\ServiceManager\Config;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/test/Annotation/AbstractBuilderTestCase.php
+++ b/test/Annotation/AbstractBuilderTestCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace LaminasTest\Form\Annotation;
 
+use Doctrine\Common\Annotations\AnnotationException;
 use Generator;
 use Laminas\Form\Annotation;
 use Laminas\Form\Element;
@@ -406,37 +407,37 @@ abstract class AbstractBuilderTestCase extends TestCase
 
     public function testLegacyComposedObjectAnnotation(): void
     {
-        $this->expectDeprecation();
-        $this->expectDeprecationMessageMatches('/Passing a single array .* is deprecated/');
+        $this->expectException(AnnotationException::class);
+        $this->expectExceptionMessageMatches('/Passing a single array .* is deprecated/');
         $entity  = new TestAsset\Annotation\LegacyComposedObjectAnnotation();
         $builder = $this->createBuilder();
-        $form    = $builder->createForm($entity);
+        $builder->createForm($entity);
     }
 
     public function testLegacyStyleFilterAnnotations(): void
     {
-        $this->expectDeprecation();
-        $this->expectDeprecationMessageMatches('/Passing a single array .* is deprecated/');
+        $this->expectException(AnnotationException::class);
+        $this->expectExceptionMessageMatches('/Passing a single array .* is deprecated/');
         $entity  = new TestAsset\Annotation\LegacyFilterAnnotation();
         $builder = $this->createBuilder();
-        $form    = $builder->createForm($entity);
+        $builder->createForm($entity);
     }
 
     public function testLegacyStyleHydratorAnnotations(): void
     {
-        $this->expectDeprecation();
-        $this->expectDeprecationMessageMatches('/Passing a single array .* is deprecated/');
+        $this->expectException(AnnotationException::class);
+        $this->expectExceptionMessageMatches('/Passing a single array .* is deprecated/');
         $entity  = new TestAsset\Annotation\LegacyHydratorAnnotation();
         $builder = $this->createBuilder();
-        $form    = $builder->createForm($entity);
+        $builder->createForm($entity);
     }
 
     public function testLegacyStyleValidatorAnnotations(): void
     {
-        $this->expectDeprecation();
-        $this->expectDeprecationMessageMatches('/Passing a single array .* is deprecated/');
+        $this->expectException(AnnotationException::class);
+        $this->expectExceptionMessageMatches('/Passing a single array .* is deprecated/');
         $entity  = new TestAsset\Annotation\LegacyValidatorAnnotation();
         $builder = $this->createBuilder();
-        $form    = $builder->createForm($entity);
+        $builder->createForm($entity);
     }
 }

--- a/test/Annotation/AbstractBuilderTestCase.php
+++ b/test/Annotation/AbstractBuilderTestCase.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace LaminasTest\Form\Annotation;
 
-use Doctrine\Common\Annotations\AnnotationException;
 use Generator;
 use Laminas\Form\Annotation;
 use Laminas\Form\Element;
@@ -23,6 +22,7 @@ use LaminasTest\Form\TestAsset\Annotation\Form;
 use LaminasTest\Form\TestAsset\Annotation\InputFilter;
 use LaminasTest\Form\TestAsset\Annotation\InputFilterInput;
 use PHPUnit\Framework\TestCase;
+use Throwable;
 
 use function getenv;
 
@@ -407,37 +407,49 @@ abstract class AbstractBuilderTestCase extends TestCase
 
     public function testLegacyComposedObjectAnnotation(): void
     {
-        $this->expectException(AnnotationException::class);
-        $this->expectExceptionMessageMatches('/Passing a single array .* is deprecated/');
-        $entity  = new TestAsset\Annotation\LegacyComposedObjectAnnotation();
-        $builder = $this->createBuilder();
-        $builder->createForm($entity);
+        try {
+            $entity  = new TestAsset\Annotation\LegacyComposedObjectAnnotation();
+            $builder = $this->createBuilder();
+            $builder->createForm($entity);
+            self::fail('Neither a deprecation nor an exception were thrown');
+        } catch (Throwable $error) {
+            self::assertMatchesRegularExpression('/Passing a single array .* is deprecated/', $error->getMessage());
+        }
     }
 
     public function testLegacyStyleFilterAnnotations(): void
     {
-        $this->expectException(AnnotationException::class);
-        $this->expectExceptionMessageMatches('/Passing a single array .* is deprecated/');
-        $entity  = new TestAsset\Annotation\LegacyFilterAnnotation();
-        $builder = $this->createBuilder();
-        $builder->createForm($entity);
+        try {
+            $entity  = new TestAsset\Annotation\LegacyFilterAnnotation();
+            $builder = $this->createBuilder();
+            $builder->createForm($entity);
+            self::fail('Neither a deprecation nor an exception were thrown');
+        } catch (Throwable $error) {
+            self::assertMatchesRegularExpression('/Passing a single array .* is deprecated/', $error->getMessage());
+        }
     }
 
     public function testLegacyStyleHydratorAnnotations(): void
     {
-        $this->expectException(AnnotationException::class);
-        $this->expectExceptionMessageMatches('/Passing a single array .* is deprecated/');
-        $entity  = new TestAsset\Annotation\LegacyHydratorAnnotation();
-        $builder = $this->createBuilder();
-        $builder->createForm($entity);
+        try {
+            $entity  = new TestAsset\Annotation\LegacyHydratorAnnotation();
+            $builder = $this->createBuilder();
+            $builder->createForm($entity);
+            self::fail('Neither a deprecation nor an exception were thrown');
+        } catch (Throwable $error) {
+            self::assertMatchesRegularExpression('/Passing a single array .* is deprecated/', $error->getMessage());
+        }
     }
 
     public function testLegacyStyleValidatorAnnotations(): void
     {
-        $this->expectException(AnnotationException::class);
-        $this->expectExceptionMessageMatches('/Passing a single array .* is deprecated/');
-        $entity  = new TestAsset\Annotation\LegacyValidatorAnnotation();
-        $builder = $this->createBuilder();
-        $builder->createForm($entity);
+        try {
+            $entity  = new TestAsset\Annotation\LegacyValidatorAnnotation();
+            $builder = $this->createBuilder();
+            $builder->createForm($entity);
+            self::fail('Neither a deprecation nor an exception were thrown');
+        } catch (Throwable $error) {
+            self::assertMatchesRegularExpression('/Passing a single array .* is deprecated/', $error->getMessage());
+        }
     }
 }

--- a/test/Annotation/BuilderAbstractFactoryTest.php
+++ b/test/Annotation/BuilderAbstractFactoryTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace LaminasTest\Form\Annotation;
 
-use Interop\Container\ContainerInterface;
+use Interop\Container\ContainerInterface; // phpcs:disable WebimpressCodingStandard.PHP.CorrectClassNameCase
 use Laminas\EventManager\EventManagerInterface;
 use Laminas\EventManager\ListenerAggregateInterface;
 use Laminas\Form\Annotation\AnnotationBuilder;

--- a/test/ElementFactoryTest.php
+++ b/test/ElementFactoryTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace LaminasTest\Form;
 
 use Generator;
-use Interop\Container\ContainerInterface;
+use Interop\Container\ContainerInterface; // phpcs:disable WebimpressCodingStandard.PHP.CorrectClassNameCase
 use Laminas\Form\ElementFactory;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use LaminasTest\Form\TestAsset\ArgumentRecorder;

--- a/test/FormAbstractServiceFactoryTest.php
+++ b/test/FormAbstractServiceFactoryTest.php
@@ -34,13 +34,11 @@ final class FormAbstractServiceFactoryTest extends TestCase
         $inputFilters = new InputFilterPluginManager($services);
         $validators   = new ValidatorPluginManager($services);
 
-        $services->setService('FilterManager', $filters);
-        $services->setService('FormElementManager', $elements);
-        $services->setService('HydratorManager', $hydrators);
-        $services->setService('InputFilterManager', $inputFilters);
-        $services->setService('ValidatorManager', $validators);
-
-        $inputFilters->setInvokableClass('FooInputFilter', InputFilter::class);
+        $services->setService(FilterPluginManager::class, $filters);
+        $services->setService(FormElementManager::class, $elements);
+        $services->setService(HydratorPluginManager::class, $hydrators);
+        $services->setService(InputFilterPluginManager::class, $inputFilters);
+        $services->setService(ValidatorPluginManager::class, $validators);
 
         $forms = $this->forms = new FormAbstractServiceFactory();
         $services->addAbstractFactory($forms);
@@ -121,7 +119,7 @@ final class FormAbstractServiceFactoryTest extends TestCase
     public function testFormCanBeCreatedViaInteractionOfAllManagers(): void
     {
         $formConfig = [
-            'hydrator'     => 'ObjectPropertyHydrator',
+            'hydrator'     => ObjectPropertyHydrator::class,
             'type'         => Form::class,
             'elements'     => [
                 [
@@ -134,7 +132,7 @@ final class FormAbstractServiceFactoryTest extends TestCase
                     ],
                 ],
             ],
-            'input_filter' => 'FooInputFilter',
+            'input_filter' => InputFilter::class,
         ];
         $config     = ['forms' => ['Foo' => $formConfig]];
         $this->services->setService('config', $config);
@@ -149,8 +147,8 @@ final class FormAbstractServiceFactoryTest extends TestCase
 
         $inputFactory = $inputFilter->getFactory();
         $this->assertInstanceOf(Factory::class, $inputFactory);
-        $filters    = $this->services->get('FilterManager');
-        $validators = $this->services->get('ValidatorManager');
+        $filters    = $this->services->get(FilterPluginManager::class);
+        $validators = $this->services->get(ValidatorPluginManager::class);
         $this->assertSame($filters, $inputFactory->getDefaultFilterChain()->getPluginManager());
         $this->assertSame($validators, $inputFactory->getDefaultValidatorChain()->getPluginManager());
     }
@@ -158,7 +156,7 @@ final class FormAbstractServiceFactoryTest extends TestCase
     public function testFormCanBeCreatedViaInteractionOfAllManagersExceptInputFilterManager(): void
     {
         $formConfig = [
-            'hydrator'     => 'ObjectPropertyHydrator',
+            'hydrator'     => ObjectPropertyHydrator::class,
             'type'         => Form::class,
             'elements'     => [
                 [
@@ -199,8 +197,8 @@ final class FormAbstractServiceFactoryTest extends TestCase
         $this->assertInstanceOf(InputFilter::class, $inputFilter);
 
         $inputFactory = $inputFilter->getFactory();
-        $filters      = $this->services->get('FilterManager');
-        $validators   = $this->services->get('ValidatorManager');
+        $filters      = $this->services->get(FilterPluginManager::class);
+        $validators   = $this->services->get(ValidatorPluginManager::class);
         $this->assertSame($filters, $inputFactory->getDefaultFilterChain()->getPluginManager());
         $this->assertSame($validators, $inputFactory->getDefaultValidatorChain()->getPluginManager());
     }

--- a/test/FormElementManagerFactoryTest.php
+++ b/test/FormElementManagerFactoryTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace LaminasTest\Form;
 
-use Interop\Container\ContainerInterface;
+use Interop\Container\ContainerInterface; // phpcs:disable WebimpressCodingStandard.PHP.CorrectClassNameCase
 use Laminas\Form\Element\Number;
 use Laminas\Form\ElementInterface;
 use Laminas\Form\FormElementManager;

--- a/test/TestAsset/CustomCreatedFormFactory.php
+++ b/test/TestAsset/CustomCreatedFormFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace LaminasTest\Form\TestAsset;
 
 use DateTime;
-use Interop\Container\ContainerInterface;
+use Interop\Container\ContainerInterface; // phpcs:disable WebimpressCodingStandard.PHP.CorrectClassNameCase
 use Laminas\ServiceManager\Factory\FactoryInterface;
 
 class CustomCreatedFormFactory implements FactoryInterface

--- a/test/TestAsset/FieldsetWithDependencyFactory.php
+++ b/test/TestAsset/FieldsetWithDependencyFactory.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace LaminasTest\Form\TestAsset;
 
-use Interop\Container\ContainerInterface;
+use Interop\Container\ContainerInterface; // phpcs:disable WebimpressCodingStandard.PHP.CorrectClassNameCase
 use Laminas\ServiceManager\Factory\FactoryInterface;
 
 class FieldsetWithDependencyFactory implements FactoryInterface


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

Doctrine Annotations now converts deprecations to exceptions (ref: https://github.com/doctrine/annotations/pull/438) but it's difficult to tell when the internal call to `trigger_error` for the deprecation fires vs the exception thrown from annotations, event though `convertDeprecationsToExceptions` is active here.

This pull also updates `inputfilter` to the latest release WRT https://github.com/laminas/laminas-inputfilter/pull/60

A failing test was occurring, due to other changes in InputFilter where factories are now fetching the `InputFilterManager` et al by FQCN rather than alias. This broke the `FormAbstractServiceFactoryTest` because of the contrived ServiceManager config. This shouldn't be an issue for consumers because they would be pulling services from a fully configured ServiceManger _(The aliases and services haven't changed)_

This should help other pulls to go green on latest deps

