### PR TITLE
Fix regular expression matching date patterns in date/datetime `<select/>`-based helpers, allowing support for other locales

### DIFF
--- a/src/View/Helper/AbstractFormDateSelect.php
+++ b/src/View/Helper/AbstractFormDateSelect.php
@@ -75,7 +75,7 @@ abstract class AbstractFormDateSelect extends AbstractHelper
     {
         $pattern    = $this->getPattern();
         $pregResult = preg_split(
-            "/([ -,.\/]*(?:'[a-zA-Z]+')*[ -,.\/]+)/",
+            "/([ \-,.\/]*(?:'[a-zA-Z]+')*[ \-,.\/]+)/",
             $pattern,
             -1,
             PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY

--- a/src/View/Helper/FormDateTimeSelect.php
+++ b/src/View/Helper/FormDateTimeSelect.php
@@ -195,7 +195,7 @@ class FormDateTimeSelect extends AbstractFormDateSelect
     {
         $pattern    = $this->getPattern();
         $pregResult = preg_split(
-            "/([ -,.:\/]*'.*?'[ -,.:\/]*)|([ -,.:\/]+)/",
+            "/([ \-,.:\/]*'.*?'[ \-,.:\/]*)|([ \-,.:\/]+)/",
             $pattern,
             -1,
             PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY

--- a/test/View/Helper/FormDateSelectTest.php
+++ b/test/View/Helper/FormDateSelectTest.php
@@ -9,6 +9,8 @@ use Laminas\Form\Element\DateSelect;
 use Laminas\Form\Element\Select;
 use Laminas\Form\Exception\DomainException;
 use Laminas\Form\View\Helper\FormDateSelect as FormDateSelectHelper;
+use ReflectionException;
+use ReflectionMethod;
 
 use function extension_loaded;
 
@@ -114,5 +116,29 @@ final class FormDateSelectTest extends AbstractCommonTestCase
         }
 
         $this->assertCount(31, $elements[0]->getValueOptions());
+    }
+
+    /**
+     * @group issue-160
+     * @throws ReflectionException
+     */
+    public function testParsePatternWithShortDateFormat(): void
+    {
+        $element  = new DateSelect('foo');
+        $dateType = IntlDateFormatter::SHORT;
+        $locale   = 'es_CL';
+
+        $this->helper->setLocale($locale);
+        $this->helper->setDateType($dateType);
+
+        $method = new ReflectionMethod($this->helper, 'parsePattern');
+        $method->setAccessible(true);
+
+        $pattern = $method->invoke($this->helper, $element->shouldRenderDelimiters());
+
+        $this->assertIsArray($pattern);
+        $this->assertArrayHasKey('day', $pattern);
+        $this->assertArrayHasKey('month', $pattern);
+        $this->assertArrayHasKey('year', $pattern);
     }
 }

--- a/test/View/Helper/FormDateSelectTest.php
+++ b/test/View/Helper/FormDateSelectTest.php
@@ -9,8 +9,6 @@ use Laminas\Form\Element\DateSelect;
 use Laminas\Form\Element\Select;
 use Laminas\Form\Exception\DomainException;
 use Laminas\Form\View\Helper\FormDateSelect as FormDateSelectHelper;
-use ReflectionException;
-use ReflectionMethod;
 
 use function extension_loaded;
 
@@ -119,26 +117,82 @@ final class FormDateSelectTest extends AbstractCommonTestCase
     }
 
     /**
-     * @group issue-160
-     * @throws ReflectionException
+     * The `es_CL` locale has a short date pattern of `dd-MM-yy HH:mm:ss`, which should be
+     * supported by our internal pattern parsing logic.
+     *
+     * This test verifies that such a pattern is correctly identified internally, and that
+     * our date rendering matches the pattern too.
+     *
+     * This kind of test could be repeated for all defined locales, but `es_CL` is sufficient
+     * for now, since this test was initially designed to catch a regression in the logic
+     * that reads out `ext-intl` patterns for us.
+     *
+     * @group 160
+     * @group 184
      */
-    public function testParsePatternWithShortDateFormat(): void
+    public function testRendersDatesWithEsCLLocaleDatePattern(): void
     {
-        $element  = new DateSelect('foo');
-        $dateType = IntlDateFormatter::SHORT;
-        $locale   = 'es_CL';
+        $this->helper->setLocale('es_CL');
+        $this->helper->setDateType(IntlDateFormatter::SHORT);
 
-        $this->helper->setLocale($locale);
-        $this->helper->setDateType($dateType);
+        $element = new DateSelect('foo');
+        $element->setMinYear(2022);
+        $element->setMaxYear(2022);
 
-        $method = new ReflectionMethod($this->helper, 'parsePattern');
-        $method->setAccessible(true);
-
-        $pattern = $method->invoke($this->helper, $element->shouldRenderDelimiters());
-
-        $this->assertIsArray($pattern);
-        $this->assertArrayHasKey('day', $pattern);
-        $this->assertArrayHasKey('month', $pattern);
-        $this->assertArrayHasKey('year', $pattern);
+        self::assertXmlStringEqualsXmlString(
+            <<<'XML'
+<html>
+    <select name="day">
+        <option value="01">01</option>
+        <option value="02">02</option>
+        <option value="03">03</option>
+        <option value="04">04</option>
+        <option value="05">05</option>
+        <option value="06">06</option>
+        <option value="07">07</option>
+        <option value="08">08</option>
+        <option value="09">09</option>
+        <option value="10">10</option>
+        <option value="11">11</option>
+        <option value="12">12</option>
+        <option value="13">13</option>
+        <option value="14">14</option>
+        <option value="15">15</option>
+        <option value="16">16</option>
+        <option value="17">17</option>
+        <option value="18">18</option>
+        <option value="19">19</option>
+        <option value="20">20</option>
+        <option value="21">21</option>
+        <option value="22">22</option>
+        <option value="23">23</option>
+        <option value="24">24</option>
+        <option value="25">25</option>
+        <option value="26">26</option>
+        <option value="27">27</option>
+        <option value="28">28</option>
+        <option value="29">29</option>
+        <option value="30">30</option>
+        <option value="31">31</option>
+    </select>-<select name="month">
+        <option value="01">01</option>
+        <option value="02">02</option>
+        <option value="03">03</option>
+        <option value="04">04</option>
+        <option value="05">05</option>
+        <option value="06">06</option>
+        <option value="07">07</option>
+        <option value="08">08</option>
+        <option value="09">09</option>
+        <option value="10">10</option>
+        <option value="11">11</option>
+        <option value="12">12</option>
+    </select>-<select name="year">
+        <option value="2022">2022</option>
+    </select>
+</html>
+XML,
+            '<html>' . $this->helper->render($element) . '</html>'
+        );
     }
 }

--- a/test/View/Helper/FormDateTimeSelectTest.php
+++ b/test/View/Helper/FormDateTimeSelectTest.php
@@ -133,4 +133,170 @@ final class FormDateTimeSelectTest extends AbstractCommonTestCase
         // closing tag and not the delimiter
         $this->assertEquals('>', substr($markup, -1));
     }
+
+    /**
+     * The `es_CL` locale has a short date pattern of `dd-MM-yy`, which should be supported
+     * by our internal pattern parsing logic.
+     *
+     * This test verifies that such a pattern is correctly identified internally, and that
+     * our date rendering matches the pattern too.
+     *
+     * This kind of test could be repeated for all defined locales, but `es_CL` is sufficient
+     * for now, since this test was initially designed to catch a regression in the logic
+     * that reads out `ext-intl` patterns for us.
+     *
+     * @group 160
+     * @group 184
+     */
+    public function testRendersDatesWithEsCLLocaleDatePattern(): void
+    {
+        $this->helper->setLocale('es_CL');
+        $this->helper->setDateType(IntlDateFormatter::SHORT);
+
+        $element = new DateTimeSelect('foo');
+        $element->setMinYear(2022);
+        $element->setMaxYear(2022);
+
+        self::assertXmlStringEqualsXmlString(
+            <<<'XML'
+<html>
+    <select name="day">
+        <option value="01">01</option>
+        <option value="02">02</option>
+        <option value="03">03</option>
+        <option value="04">04</option>
+        <option value="05">05</option>
+        <option value="06">06</option>
+        <option value="07">07</option>
+        <option value="08">08</option>
+        <option value="09">09</option>
+        <option value="10">10</option>
+        <option value="11">11</option>
+        <option value="12">12</option>
+        <option value="13">13</option>
+        <option value="14">14</option>
+        <option value="15">15</option>
+        <option value="16">16</option>
+        <option value="17">17</option>
+        <option value="18">18</option>
+        <option value="19">19</option>
+        <option value="20">20</option>
+        <option value="21">21</option>
+        <option value="22">22</option>
+        <option value="23">23</option>
+        <option value="24">24</option>
+        <option value="25">25</option>
+        <option value="26">26</option>
+        <option value="27">27</option>
+        <option value="28">28</option>
+        <option value="29">29</option>
+        <option value="30">30</option>
+        <option value="31">31</option>
+    </select>-<select name="month">
+        <option value="01">01</option>
+        <option value="02">02</option>
+        <option value="03">03</option>
+        <option value="04">04</option>
+        <option value="05">05</option>
+        <option value="06">06</option>
+        <option value="07">07</option>
+        <option value="08">08</option>
+        <option value="09">09</option>
+        <option value="10">10</option>
+        <option value="11">11</option>
+        <option value="12">12</option>
+    </select>-<select name="year">
+        <option value="2022">2022</option>
+    </select> <select name="hour">
+        <option value="00">00</option>
+        <option value="01">01</option>
+        <option value="02">02</option>
+        <option value="03">03</option>
+        <option value="04">04</option>
+        <option value="05">05</option>
+        <option value="06">06</option>
+        <option value="07">07</option>
+        <option value="08">08</option>
+        <option value="09">09</option>
+        <option value="10">10</option>
+        <option value="11">11</option>
+        <option value="12">12</option>
+        <option value="13">13</option>
+        <option value="14">14</option>
+        <option value="15">15</option>
+        <option value="16">16</option>
+        <option value="17">17</option>
+        <option value="18">18</option>
+        <option value="19">19</option>
+        <option value="20">20</option>
+        <option value="21">21</option>
+        <option value="22">22</option>
+        <option value="23">23</option>
+    </select>:<select name="minute">
+        <option value="00">00</option>
+        <option value="01">01</option>
+        <option value="02">02</option>
+        <option value="03">03</option>
+        <option value="04">04</option>
+        <option value="05">05</option>
+        <option value="06">06</option>
+        <option value="07">07</option>
+        <option value="08">08</option>
+        <option value="09">09</option>
+        <option value="10">10</option>
+        <option value="11">11</option>
+        <option value="12">12</option>
+        <option value="13">13</option>
+        <option value="14">14</option>
+        <option value="15">15</option>
+        <option value="16">16</option>
+        <option value="17">17</option>
+        <option value="18">18</option>
+        <option value="19">19</option>
+        <option value="20">20</option>
+        <option value="21">21</option>
+        <option value="22">22</option>
+        <option value="23">23</option>
+        <option value="24">24</option>
+        <option value="25">25</option>
+        <option value="26">26</option>
+        <option value="27">27</option>
+        <option value="28">28</option>
+        <option value="29">29</option>
+        <option value="30">30</option>
+        <option value="31">31</option>
+        <option value="32">32</option>
+        <option value="33">33</option>
+        <option value="34">34</option>
+        <option value="35">35</option>
+        <option value="36">36</option>
+        <option value="37">37</option>
+        <option value="38">38</option>
+        <option value="39">39</option>
+        <option value="40">40</option>
+        <option value="41">41</option>
+        <option value="42">42</option>
+        <option value="43">43</option>
+        <option value="44">44</option>
+        <option value="45">45</option>
+        <option value="46">46</option>
+        <option value="47">47</option>
+        <option value="48">48</option>
+        <option value="49">49</option>
+        <option value="50">50</option>
+        <option value="51">51</option>
+        <option value="52">52</option>
+        <option value="53">53</option>
+        <option value="54">54</option>
+        <option value="55">55</option>
+        <option value="56">56</option>
+        <option value="57">57</option>
+        <option value="58">58</option>
+        <option value="59">59</option>
+    </select>
+</html>
+XML,
+            '<html>' . $this->helper->render($element) . '</html>'
+        );
+    }
 }


### PR DESCRIPTION
This will escape some meta characters.

Fixes #160 
