### PR TITLE
adding support of passwordrules option to password element rendering

### DIFF
--- a/src/View/Helper/FormPassword.php
+++ b/src/View/Helper/FormPassword.php
@@ -14,20 +14,21 @@ class FormPassword extends FormInput
      * @var array
      */
     protected $validTagAttributes = [
-        'name'         => true,
-        'autocomplete' => true,
-        'autofocus'    => true,
-        'disabled'     => true,
-        'form'         => true,
-        'maxlength'    => true,
-        'minlength'    => true,
-        'pattern'      => true,
-        'placeholder'  => true,
-        'readonly'     => true,
-        'required'     => true,
-        'size'         => true,
-        'type'         => true,
-        'value'        => true,
+        'name'          => true,
+        'autocomplete'  => true,
+        'autofocus'     => true,
+        'disabled'      => true,
+        'form'          => true,
+        'maxlength'     => true,
+        'minlength'     => true,
+        'pattern'       => true,
+        'placeholder'   => true,
+        'readonly'      => true,
+        'required'      => true,
+        'size'          => true,
+        'type'          => true,
+        'value'         => true,
+        'passwordrules' => true,
     ];
 
     /**

--- a/test/View/Helper/FormPasswordTest.php
+++ b/test/View/Helper/FormPasswordTest.php
@@ -79,6 +79,7 @@ final class FormPasswordTest extends AbstractCommonTestCase
             ['step', 'assertStringNotContainsString'],
             ['value', 'assertStringContainsString'],
             ['width', 'assertStringNotContainsString'],
+            ['passwordrules', 'assertStringContainsString'],
         ];
     }
 
@@ -116,6 +117,7 @@ final class FormPasswordTest extends AbstractCommonTestCase
             'src'            => 'value',
             'step'           => 'value',
             'width'          => 'value',
+            'passwordrules'  => 'value',
         ]);
         $element->setValue('value');
         return $element;


### PR DESCRIPTION
Adding support of passwordrules option for password element based on apple and 1password recommendation https://developer.apple.com/password-rules/ 

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | yes

### Description

1password and Apple support options for automatic password generation for this they are using option password rules
e.q. 
`<input type="password" passwordrules="minlength: 8; maxlength: 36; required: lower; required: upper; required: digit; required: [-];">` 
it will allow automatically generate password like: "suhxe6-buwBum-zakvab", "hegxop-6ranqa-dIzkem" 
All of this provides easier path for users who struggle to generate suitable password 

- added option "passwordrules" to attributes supported by View/Helper/Password 
- in order to reproduce build element password with password rules attribute
- expectation: view/helper/password renders option passwordrules appear
- tests to cover this case - added
