### PR TITLE
Add internal stub for psr container, updating export-ignores

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,3 @@
-/.coveralls.yml export-ignore
 /.gitattributes export-ignore
 /.github/ export-ignore
 /.gitignore export-ignore
@@ -7,6 +6,9 @@
 /mkdocs.yml export-ignore
 /phpcs.xml export-ignore
 /phpunit.xml.dist export-ignore
-/psalm.xml.dist export-ignore
+/psalm.xml export-ignore
 /psalm-baseline.xml export-ignore
 /test/ export-ignore
+/.psr-container.php.stub export-ignore
+/renovate.json export-ignore
+/composer.lock export-ignore

--- a/.psr-container.php.stub
+++ b/.psr-container.php.stub
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psr\Container {
+    /**
+     * Provides automatic type inference for Psalm when retrieving a service from a container using a FQCN
+     */
+    interface ContainerInterface
+    {
+        /**
+         * @param string|class-string $id
+         * @return bool
+         */
+        public function has(string $id);
+
+        /**
+         * @template T
+         * @psalm-param string|class-string<T> $id
+         * @psalm-return ($id is class-string ? T : mixed)
+         */
+        public function get(string $id);
+    }
+}

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -293,9 +293,6 @@
       <code>$factories</code>
       <code>$instanceOf</code>
     </NonInvariantDocblockPropertyType>
-    <ParamNameMismatch occurrences="1">
-      <code>$name</code>
-    </ParamNameMismatch>
     <RedundantConditionGivenDocblockType occurrences="6">
       <code>$services</code>
       <code>$services</code>

--- a/psalm.xml
+++ b/psalm.xml
@@ -38,4 +38,7 @@
     <plugins>
         <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
     </plugins>
+    <stubs>
+        <file name=".psr-container.php.stub"/>
+    </stubs>
 </psalm>

--- a/test/TestAsset/CustomCreatedFormFactory.php
+++ b/test/TestAsset/CustomCreatedFormFactory.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace LaminasTest\Form\TestAsset;
 
 use DateTime;
-use Interop\Container\ContainerInterface; // phpcs:disable WebimpressCodingStandard.PHP.CorrectClassNameCase
 use Laminas\ServiceManager\Factory\FactoryInterface;
+use Psr\Container\ContainerInterface;
 
 class CustomCreatedFormFactory implements FactoryInterface
 {

--- a/test/TestAsset/FieldsetWithDependencyFactory.php
+++ b/test/TestAsset/FieldsetWithDependencyFactory.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace LaminasTest\Form\TestAsset;
 
-use Interop\Container\ContainerInterface; // phpcs:disable WebimpressCodingStandard.PHP.CorrectClassNameCase
 use Laminas\ServiceManager\Factory\FactoryInterface;
+use Psr\Container\ContainerInterface;
 
 class FieldsetWithDependencyFactory implements FactoryInterface
 {


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| New Feature   | yes
| QA            | yes

### Description

Adding the stub doesn't have much impact here because most of the `get`'s use aliases. It'll probably be more useful when `psalm.xml` goes to level 1 perhaps?

Would you accept a PR to update calls to `$container->get('FormElementManager')` to `$container->get(FormElementManager::class)` _(And similar)_ ???