### PR TITLE
Retrieve dependencies by FQCN where appropriate

### DIFF
--- a/docs/book/v2/advanced.md
+++ b/docs/book/v2/advanced.md
@@ -265,14 +265,15 @@ This now requires a factory to inject the form instance:
 ```php
 namespace Application\Controller;
 
-use Interop\Container\ContainerInterface;
 use Application\Form\MyForm;
+use Laminas\Form\FormElementManager;
+use Psr\Container\ContainerInterface;
 
 class IndexControllerFactory
 {
     public function __invoke(ContainerInterface $container)
     {
-        $formManager = $container->get('FormElementManager');
+        $formManager = $container->get(FormElementManager::class);
         return new IndexController($formManager->get(MyForm::class));
     }
 }

--- a/docs/book/v2/application-integration/usage-in-a-laminas-mvc-application.md
+++ b/docs/book/v2/application-integration/usage-in-a-laminas-mvc-application.md
@@ -128,15 +128,15 @@ e.g. `src/Album/Controller/AlbumControllerFactory.php`:
 namespace Album\Controller;
 
 use Album\Form\AlbumForm;
-use Laminas\ServiceManager\PluginManagerInterface;
+use Laminas\Form\FormElementManager;
 use Psr\Container\ContainerInterface;
 
 class AlbumControllerFactory
 {
     public function __invoke(ContainerInterface $container) : AlbumController
     {
-        /** @var PluginManagerInterface $formElementManager */
-        $formElementManager = $container->get('FormElementManager');
+        /** @var FormElementManager $formElementManager */
+        $formElementManager = $container->get(FormElementManager::class);
         /** @var AlbumForm */ 
         $form = $formElementManager->get(AlbumForm::class);
 

--- a/docs/book/v3/advanced.md
+++ b/docs/book/v3/advanced.md
@@ -265,14 +265,15 @@ This now requires a factory to inject the form instance:
 ```php
 namespace Application\Controller;
 
-use Interop\Container\ContainerInterface;
 use Application\Form\MyForm;
+use Laminas\Form\FormElementManager;
+use Psr\Container\ContainerInterface;
 
 class IndexControllerFactory
 {
     public function __invoke(ContainerInterface $container)
     {
-        $formManager = $container->get('FormElementManager');
+        $formManager = $container->get(FormElementManager::class);
         return new IndexController($formManager->get(MyForm::class));
     }
 }

--- a/src/Annotation/BuilderAbstractFactory.php
+++ b/src/Annotation/BuilderAbstractFactory.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Laminas\Form\Annotation;
 
-use Interop\Container\ContainerInterface; // phpcs:disable WebimpressCodingStandard.PHP.CorrectClassNameCase
 use Laminas\EventManager\EventManagerInterface;
 use Laminas\EventManager\ListenerAggregateInterface;
 use Laminas\Form\Factory;
+use Laminas\Form\FormElementManager;
+use Laminas\InputFilter\InputFilterPluginManager;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Factory\AbstractFactoryInterface;
+use Psr\Container\ContainerInterface;
 
 use function is_array;
 use function is_subclass_of;
@@ -121,10 +123,10 @@ final class BuilderAbstractFactory implements AbstractFactoryInterface
      */
     private function injectFactory(Factory $factory, ContainerInterface $container): void
     {
-        $factory->setFormElementManager($container->get('FormElementManager'));
+        $factory->setFormElementManager($container->get(FormElementManager::class));
 
-        if ($container->has('InputFilterManager')) {
-            $inputFilters = $container->get('InputFilterManager');
+        if ($container->has(InputFilterPluginManager::class)) {
+            $inputFilters = $container->get(InputFilterPluginManager::class);
             $factory->getInputFilterFactory()->setInputFilterManager($inputFilters);
         }
     }

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -34,14 +34,14 @@ final class ConfigProvider
                 FormAbstractServiceFactory::class,
             ],
             'aliases'            => [
-                Annotation\AnnotationBuilder::class => 'FormAnnotationBuilder',
-                Annotation\AttributeBuilder::class  => 'FormAttributeBuilder',
-                FormElementManager::class           => 'FormElementManager',
+                'FormAnnotationBuilder' => Annotation\AnnotationBuilder::class,
+                'FormAttributeBuilder'  => Annotation\AttributeBuilder::class,
+                'FormElementManager'    => FormElementManager::class,
             ],
             'factories'          => [
-                'FormAnnotationBuilder' => Annotation\BuilderAbstractFactory::class,
-                'FormAttributeBuilder'  => Annotation\BuilderAbstractFactory::class,
-                'FormElementManager'    => FormElementManagerFactory::class,
+                Annotation\AnnotationBuilder::class => Annotation\BuilderAbstractFactory::class,
+                Annotation\AttributeBuilder::class  => Annotation\BuilderAbstractFactory::class,
+                FormElementManager::class           => FormElementManagerFactory::class,
             ],
         ];
     }

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -34,14 +34,14 @@ final class ConfigProvider
                 FormAbstractServiceFactory::class,
             ],
             'aliases'            => [
-                'FormAnnotationBuilder' => Annotation\AnnotationBuilder::class,
-                'FormAttributeBuilder'  => Annotation\AttributeBuilder::class,
-                'FormElementManager'    => FormElementManager::class,
+                Annotation\AnnotationBuilder::class => 'FormAnnotationBuilder',
+                Annotation\AttributeBuilder::class  => 'FormAttributeBuilder',
+                FormElementManager::class           => 'FormElementManager',
             ],
             'factories'          => [
-                Annotation\AnnotationBuilder::class => Annotation\BuilderAbstractFactory::class,
-                Annotation\AttributeBuilder::class  => Annotation\BuilderAbstractFactory::class,
-                FormElementManager::class           => FormElementManagerFactory::class,
+                'FormAnnotationBuilder' => Annotation\BuilderAbstractFactory::class,
+                'FormAttributeBuilder'  => Annotation\BuilderAbstractFactory::class,
+                'FormElementManager'    => FormElementManagerFactory::class,
             ],
         ];
     }

--- a/src/FormElementManager.php
+++ b/src/FormElementManager.php
@@ -6,6 +6,9 @@ namespace Laminas\Form;
 
 use Interop\Container\ContainerInterface; // phpcs:disable WebimpressCodingStandard.PHP.CorrectClassNameCase
 use Laminas\Form\Exception;
+use Laminas\Hydrator\HydratorInterface;
+use Laminas\Hydrator\HydratorPluginManager;
+use Laminas\InputFilter\InputFilterPluginManager;
 use Laminas\ServiceManager\AbstractPluginManager;
 use Laminas\ServiceManager\Exception\InvalidServiceException;
 use Laminas\Stdlib\InitializableInterface;
@@ -217,8 +220,8 @@ class FormElementManager extends AbstractPluginManager
         $factory = $instance->getFormFactory();
         $factory->setFormElementManager($this);
 
-        if ($container->has('InputFilterManager')) {
-            $inputFilters = $container->get('InputFilterManager');
+        if ($container->has(InputFilterPluginManager::class)) {
+            $inputFilters = $container->get(InputFilterPluginManager::class);
             $factory->getInputFilterFactory()->setInputFilterManager($inputFilters);
         }
     }
@@ -343,15 +346,17 @@ class FormElementManager extends AbstractPluginManager
     /**
      * Try to pull hydrator from the creation context, or instantiates it from its name
      *
+     * @param string|class-string<HydratorInterface> $hydratorName
      * @return mixed
+     * @psalm-return ($hydratorName is class-string<HydratorInterface> ? HydratorInterface : mixed)
      * @throws Exception\DomainException
      */
     public function getHydratorFromName(string $hydratorName)
     {
         $services = $this->creationContext;
 
-        if ($services && $services->has('HydratorManager')) {
-            $hydrators = $services->get('HydratorManager');
+        if ($services && $services->has(HydratorPluginManager::class)) {
+            $hydrators = $services->get(HydratorPluginManager::class);
             if ($hydrators->has($hydratorName)) {
                 return $hydrators->get($hydratorName);
             }

--- a/src/Module.php
+++ b/src/Module.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laminas\Form;
 
 use Laminas\ModuleManager\Feature\FormElementProviderInterface;
+use Laminas\ModuleManager\Listener\ServiceListener;
 use Laminas\ModuleManager\ModuleManager;
 
 final class Module
@@ -28,12 +29,13 @@ final class Module
      */
     public function init(ModuleManager $moduleManager): void
     {
-        $event           = $moduleManager->getEvent();
-        $container       = $event->getParam('ServiceManager');
+        $event     = $moduleManager->getEvent();
+        $container = $event->getParam('ServiceManager');
+        /** @var ServiceListener $serviceListener */
         $serviceListener = $container->get('ServiceListener');
 
         $serviceListener->addServiceManager(
-            'FormElementManager',
+            FormElementManager::class,
             'form_elements',
             FormElementProviderInterface::class,
             'getFormElementConfig'

--- a/test/Annotation/BuilderAbstractFactoryTest.php
+++ b/test/Annotation/BuilderAbstractFactoryTest.php
@@ -10,6 +10,7 @@ use Laminas\Form\Annotation\AnnotationBuilder;
 use Laminas\Form\Annotation\AttributeBuilder;
 use Laminas\Form\Annotation\BuilderAbstractFactory;
 use Laminas\Form\FormElementManager;
+use Laminas\InputFilter\InputFilterPluginManager;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\ServiceManager;
 use PHPUnit\Framework\TestCase;
@@ -26,14 +27,14 @@ final class BuilderAbstractFactoryTest extends TestCase
             ->method('get')
             ->willReturnMap([
                 ['EventManager', $events],
-                ['FormElementManager', new FormElementManager(new ServiceManager())],
+                [FormElementManager::class, new FormElementManager(new ServiceManager())],
             ]);
 
         $container->expects(self::atLeast(2))
             ->method('has')
             ->willReturnMap([
                 ['config', false],
-                ['InputFilterManager', false],
+                [InputFilterPluginManager::class, false],
             ]);
 
         $factory = new BuilderAbstractFactory();
@@ -60,14 +61,14 @@ final class BuilderAbstractFactoryTest extends TestCase
             ->method('get')
             ->willReturnMap([
                 ['EventManager', $events],
-                ['FormElementManager', new FormElementManager(new ServiceManager())],
+                [FormElementManager::class, new FormElementManager(new ServiceManager())],
             ]);
 
         $container->expects(self::atLeast(2))
             ->method('has')
             ->willReturnMap([
                 ['config', false],
-                ['InputFilterManager', false],
+                [InputFilterPluginManager::class, false],
             ]);
 
         $factory = new BuilderAbstractFactory();
@@ -99,7 +100,7 @@ final class BuilderAbstractFactoryTest extends TestCase
             ->method('get')
             ->willReturnMap([
                 ['EventManager', $events],
-                ['FormElementManager', new FormElementManager(new ServiceManager())],
+                [FormElementManager::class, new FormElementManager(new ServiceManager())],
                 ['config', $config],
             ]);
 
@@ -107,7 +108,7 @@ final class BuilderAbstractFactoryTest extends TestCase
             ->method('has')
             ->willReturnMap([
                 ['config', true],
-                ['InputFilterManager', false],
+                [InputFilterPluginManager::class, false],
             ]);
 
         $factory = new BuilderAbstractFactory();
@@ -133,7 +134,7 @@ final class BuilderAbstractFactoryTest extends TestCase
             ->method('get')
             ->willReturnMap([
                 ['EventManager', $events],
-                ['FormElementManager', new FormElementManager(new ServiceManager())],
+                [FormElementManager::class, new FormElementManager(new ServiceManager())],
                 ['config', $config],
                 ['test-listener', $listener],
             ]);
@@ -142,7 +143,7 @@ final class BuilderAbstractFactoryTest extends TestCase
             ->method('has')
             ->willReturnMap([
                 ['config', true],
-                ['InputFilterManager', false],
+                [InputFilterPluginManager::class, false],
             ]);
 
         $listener->expects(self::once())
@@ -169,7 +170,7 @@ final class BuilderAbstractFactoryTest extends TestCase
             ->method('get')
             ->willReturnMap([
                 ['EventManager', $events],
-                ['FormElementManager', new FormElementManager(new ServiceManager())],
+                [FormElementManager::class, new FormElementManager(new ServiceManager())],
                 ['config', $config],
                 [
                     'test-listener',
@@ -182,7 +183,7 @@ final class BuilderAbstractFactoryTest extends TestCase
             ->method('has')
             ->willReturnMap([
                 ['config', true],
-                ['InputFilterManager', false],
+                [InputFilterPluginManager::class, false],
             ]);
 
         $factory = new BuilderAbstractFactory();

--- a/test/FactoryTest.php
+++ b/test/FactoryTest.php
@@ -343,7 +343,7 @@ final class FactoryTest extends TestCase
         $hydratorShortName = 'ObjectPropertyHydrator';
         $hydratorType      = ObjectPropertyHydrator::class;
 
-        $this->services->setService('HydratorManager', new HydratorPluginManager($this->services));
+        $this->services->setService(HydratorPluginManager::class, new HydratorPluginManager($this->services));
 
         $form = $this->factory->createForm([
             'name'     => 'foo',

--- a/test/FieldsetTest.php
+++ b/test/FieldsetTest.php
@@ -626,10 +626,10 @@ final class FieldsetTest extends TestCase
         // Service container
         $container = $this->createMock(ContainerInterface::class);
         $container->method('has')
-            ->with('HydratorManager')
+            ->with(Hydrator\HydratorPluginManager::class)
             ->willReturn(true);
         $container->method('get')
-            ->with('HydratorManager')
+            ->with(Hydrator\HydratorPluginManager::class)
             ->willReturn($hydratorManager);
 
         $this->fieldset->getFormFactory()->setFormElementManager(

--- a/test/FormElementManagerFactoryTest.php
+++ b/test/FormElementManagerFactoryTest.php
@@ -65,7 +65,7 @@ final class FormElementManagerFactoryTest extends TestCase
             ->willReturn($config);
 
         $factory  = new FormElementManagerFactory();
-        $elements = $factory($container, 'FormElementManager');
+        $elements = $factory($container, FormElementManager::class);
 
         self::assertInstanceOf(FormElementManager::class, $elements);
         self::assertTrue($elements->has('test'));
@@ -85,7 +85,7 @@ final class FormElementManagerFactoryTest extends TestCase
             ->method('get');
 
         $factory  = new FormElementManagerFactory();
-        $elements = $factory($container, 'FormElementManager');
+        $elements = $factory($container, FormElementManager::class);
 
         self::assertInstanceOf(FormElementManager::class, $elements);
         self::assertFalse($elements->has('test'));
@@ -105,7 +105,7 @@ final class FormElementManagerFactoryTest extends TestCase
             ->method('get');
 
         $factory  = new FormElementManagerFactory();
-        $elements = $factory($container, 'FormElementManager');
+        $elements = $factory($container, FormElementManager::class);
 
         self::assertInstanceOf(FormElementManager::class, $elements);
     }
@@ -125,7 +125,7 @@ final class FormElementManagerFactoryTest extends TestCase
             ->willReturn(['foo' => 'bar']);
 
         $factory  = new FormElementManagerFactory();
-        $elements = $factory($container, 'FormElementManager');
+        $elements = $factory($container, FormElementManager::class);
 
         self::assertInstanceOf(FormElementManager::class, $elements);
         self::assertFalse($elements->has('foo'));

--- a/test/FormElementManagerTest.php
+++ b/test/FormElementManagerTest.php
@@ -12,6 +12,7 @@ use Laminas\Form\Factory;
 use Laminas\Form\Form;
 use Laminas\Form\FormElementManager;
 use Laminas\Hydrator\HydratorInterface;
+use Laminas\Hydrator\HydratorPluginManager;
 use Laminas\ServiceManager\Exception\InvalidServiceException;
 use Laminas\ServiceManager\PluginManagerInterface;
 use Laminas\ServiceManager\ServiceManager;
@@ -270,10 +271,10 @@ final class FormElementManagerTest extends TestCase
         // Service container
         $container = $this->createMock(ContainerInterface::class);
         $container->method('has')
-            ->with('HydratorManager')
+            ->with(HydratorPluginManager::class)
             ->willReturn(true);
         $container->method('get')
-            ->with('HydratorManager')
+            ->with(HydratorPluginManager::class)
             ->willReturn($hydratorManager);
 
         $formElementManager = new FormElementManager($container);

--- a/test/Integration/ServiceManagerTest.php
+++ b/test/Integration/ServiceManagerTest.php
@@ -21,14 +21,14 @@ final class ServiceManagerTest extends TestCase
         // Reproducing the behaviour of a full stack MVC + ModuleManager
         $serviceManagerConfig = new Config([
             'factories' => [
-                'FormElementManager' => FormElementManagerFactory::class,
+                FormElementManager::class => FormElementManagerFactory::class,
             ],
         ]);
 
         $serviceManager = new ServiceManager();
         $serviceManagerConfig->configureServiceManager($serviceManager);
 
-        $formElementManager = $serviceManager->get('FormElementManager');
+        $formElementManager = $serviceManager->get(FormElementManager::class);
         self::assertInstanceOf(FormElementManager::class, $formElementManager);
 
         $element     = new class extends Element {
@@ -62,13 +62,13 @@ final class ServiceManagerTest extends TestCase
         // Reproducing the behaviour of a full stack MVC + ModuleManager
         $serviceManagerConfig = new Config([
             'factories' => [
-                'FormElementManager' => FormElementManagerFactory::class,
+                FormElementManager::class => FormElementManagerFactory::class,
             ],
         ]);
 
         $serviceManager = new ServiceManager();
         $serviceManagerConfig->configureServiceManager($serviceManager);
-        $formElementManager = $serviceManager->get('FormElementManager');
+        $formElementManager = $serviceManager->get(FormElementManager::class);
         self::assertInstanceOf(FormElementManager::class, $formElementManager);
 
         $initializer = new class ($formElementManager) implements InitializerInterface


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| New Feature   | yes

### Description

This patch updates all `$container->get()` call sites to use a FQCN instead of a string alias. DI configuration is updated so that factories are registered against FQCN but maintains existing service aliases.
