### PR TITLE
Fixes #22: "ComposedObject" Annotation does not add inputSpec to element configuration

### DIFF
--- a/src/Annotation/ElementAnnotationsListener.php
+++ b/src/Annotation/ElementAnnotationsListener.php
@@ -156,7 +156,8 @@ final class ElementAnnotationsListener extends AbstractAnnotationsListener
             if (! isset($inputFilter['type'])) {
                 $inputFilter['type'] = InputFilter::class;
             }
-            $e->setParam('inputSpec', $inputFilter);
+            $inputSpec = $e->getParam('inputSpec');
+            $inputSpec->exchangeArray($inputFilter);
             unset($specification['input_filter']);
 
             // Compose specification as a fieldset into parent form/fieldset

--- a/test/Annotation/AbstractBuilderTestCase.php
+++ b/test/Annotation/AbstractBuilderTestCase.php
@@ -12,6 +12,7 @@ use Laminas\Form\Element;
 use Laminas\Form\Element\Collection;
 use Laminas\Form\Fieldset;
 use Laminas\Form\FieldsetInterface;
+use Laminas\Form\InputFilterProviderFieldset;
 use Laminas\Hydrator\ClassMethodsHydrator;
 use Laminas\Hydrator\ObjectPropertyHydrator;
 use Laminas\InputFilter\Input;
@@ -21,6 +22,7 @@ use Laminas\Stdlib\PriorityList;
 use Laminas\Validator\EmailAddress;
 use Laminas\Validator\NotEmpty;
 use Laminas\Validator\StringLength;
+use Laminas\Validator\ValidatorChain;
 use LaminasTest\Form\TestAsset;
 use LaminasTest\Form\TestAsset\Annotation\Entity;
 use LaminasTest\Form\TestAsset\Annotation\Form;
@@ -219,8 +221,11 @@ abstract class AbstractBuilderTestCase extends TestCase
         self::assertInstanceOf(InputFilterInterface::class, $composed);
         self::assertTrue($composed->has('username'));
         self::assertTrue($composed->has('password'));
-        $usernameInput      = $composed->get('username');
-        $usernameValidators = $usernameInput->getValidatorChain()->getValidators();
+        $usernameInput = $composed->get('username');
+        self::assertInstanceOf(Input::class, $usernameInput);
+        $validatorChain = $usernameInput->getValidatorChain();
+        self::assertInstanceOf(ValidatorChain::class, $validatorChain);
+        $usernameValidators = $validatorChain->getValidators();
         self::assertCount(2, $usernameValidators);
         self::assertInstanceOf(NotEmpty::class, $usernameValidators[0]['instance']);
         self::assertInstanceOf(StringLength::class, $usernameValidators[1]['instance']);
@@ -228,8 +233,10 @@ abstract class AbstractBuilderTestCase extends TestCase
         self::assertCount(1, $usernameFilters);
         self::assertInstanceOf(StringTrim::class, $usernameFilters[0]);
 
-        $passwordInput      = $composed->get('password');
-        $passwordValidators = $passwordInput->getValidatorChain()->getValidators();
+        $passwordInput = $composed->get('password');
+        self::assertInstanceOf(Input::class, $passwordInput);
+        $validatorChain     = $passwordInput->getValidatorChain();
+        $passwordValidators = $validatorChain->getValidators();
         self::assertCount(1, $passwordValidators);
         self::assertInstanceOf(EmailAddress::class, $passwordValidators[0]['instance']);
 
@@ -252,6 +259,7 @@ abstract class AbstractBuilderTestCase extends TestCase
         self::assertInstanceOf(FieldsetInterface::class, $target);
         self::assertTrue($target->has('username'));
         self::assertTrue($target->has('password'));
+        self::assertInstanceOf(InputFilterProviderFieldset::class, $target);
         $filterSpec = $target->getInputFilterSpecification();
         self::assertArrayHasKey('username', $filterSpec);
         self::assertArrayHasKey('password', $filterSpec);

--- a/test/Annotation/AbstractBuilderTestCase.php
+++ b/test/Annotation/AbstractBuilderTestCase.php
@@ -219,7 +219,7 @@ abstract class AbstractBuilderTestCase extends TestCase
         self::assertInstanceOf(InputFilterInterface::class, $composed);
         self::assertTrue($composed->has('username'));
         self::assertTrue($composed->has('password'));
-        $usernameInput = $composed->get('username');
+        $usernameInput      = $composed->get('username');
         $usernameValidators = $usernameInput->getValidatorChain()->getValidators();
         self::assertCount(2, $usernameValidators);
         self::assertInstanceOf(NotEmpty::class, $usernameValidators[0]['instance']);
@@ -228,7 +228,7 @@ abstract class AbstractBuilderTestCase extends TestCase
         self::assertCount(1, $usernameFilters);
         self::assertInstanceOf(StringTrim::class, $usernameFilters[0]);
 
-        $passwordInput = $composed->get('password');
+        $passwordInput      = $composed->get('password');
         $passwordValidators = $passwordInput->getValidatorChain()->getValidators();
         self::assertCount(1, $passwordValidators);
         self::assertInstanceOf(EmailAddress::class, $passwordValidators[0]['instance']);
@@ -257,41 +257,40 @@ abstract class AbstractBuilderTestCase extends TestCase
         self::assertArrayHasKey('password', $filterSpec);
         $usernameFilterSpec = $filterSpec['username'];
         self::assertEquals([
-            'name' => 'username',
+            'name'          => 'username',
             'error_message' => 'Invalid or missing username',
-            'required' => 1,
-            'filters' => [
+            'required'      => 1,
+            'filters'       => [
                 '0' => [
-                    'name' => 'StringTrim'
+                    'name' => 'StringTrim',
                 ],
             ],
-            'validators' => [
+            'validators'    => [
                 '0' => [
-                    'name' => 'NotEmpty'
+                    'name' => 'NotEmpty',
                 ],
-                1 => [
-                    'name' => 'StringLength',
+                1   => [
+                    'name'    => 'StringLength',
                     'options' => [
                         'min' => 3,
-                        'max' => 25
-                    ]
-
-                ]
-            ]
+                        'max' => 25,
+                    ],
+                ],
+            ],
         ], $usernameFilterSpec);
         $passwordFilterSpec = $filterSpec['password'];
         self::assertEquals([
-            'name' => 'password',
-            'filters' => [
+            'name'       => 'password',
+            'filters'    => [
                 '0' => [
-                    'name' => 'StringTrim'
+                    'name' => 'StringTrim',
                 ],
             ],
             'validators' => [
                 '0' => [
-                    'name' => 'EmailAddress'
-                ]
-            ]
+                    'name' => 'EmailAddress',
+                ],
+            ],
         ], $passwordFilterSpec);
     }
 


### PR DESCRIPTION
Signed-off-by: Raul Robledo <riul88@gmail.com>

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | yes/no
| New Feature   | no
| RFC           | yes/no
| QA            | yes/no

### Description
Fix suggested by @weierophinney 
Issue reproducible by unit test testAllowsComposingChildEntities but the test case didn't validate the filters or validators from the child entity, the unit test was updated as part of this PR to perform the missing assertions to ensure the element validators and filters are configured

The changes to unit test testAllowsComposingMultipleChildEntities which is used when ComposedObject is marked as isCollection are only preventive not impacted by the code change in the PR