### PR TITLE
Fixes #33 Collection has empty bonded nested objects

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -8,11 +8,6 @@
       <code>is_string($entity)</code>
     </RedundantConditionGivenDocblockType>
   </file>
-  <file src="src/Annotation/AnnotationBuilder.php">
-    <DeprecatedMethod>
-      <code><![CDATA[AnnotationRegistry::registerLoader('class_exists')]]></code>
-    </DeprecatedMethod>
-  </file>
   <file src="src/Annotation/AttributeBuilder.php">
     <NullArgument>
       <code>$annotations</code>
@@ -363,6 +358,9 @@
     </PossiblyNullArgument>
   </file>
   <file src="test/Annotation/AbstractBuilderTestCase.php">
+    <DocblockTypeContradiction>
+      <code>assertNotNull</code>
+    </DocblockTypeContradiction>
     <PossiblyUndefinedMethod>
       <code>allowEmpty</code>
       <code>getFilterChain</code>

--- a/src/Annotation/ElementAnnotationsListener.php
+++ b/src/Annotation/ElementAnnotationsListener.php
@@ -146,6 +146,7 @@ final class ElementAnnotationsListener extends AbstractAnnotationsListener
 
             $elementSpec['spec']['options']['target_element']                                 = $specification;
             $elementSpec['spec']['options']['target_element']['options']['input_filter_spec'] = $inputFilter;
+            $elementSpec['spec']['options']['target_element']['options']['target_type']       = $class;
 
             if (isset($specification['hydrator'])) {
                 $elementSpec['spec']['hydrator'] = $specification['hydrator'];

--- a/src/Element/Collection.php
+++ b/src/Element/Collection.php
@@ -9,6 +9,7 @@ use Laminas\Form\Exception;
 use Laminas\Form\Fieldset;
 use Laminas\Form\FieldsetInterface;
 use Laminas\Form\FormInterface;
+use Laminas\Form\InputFilterProviderFieldset;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\Exception\InvalidArgumentException;
 use Traversable;
@@ -533,9 +534,11 @@ class Collection extends Fieldset
     protected function createNewTargetElementInstance(): ElementInterface
     {
         assert($this->targetElement !== null);
-        if ($this->targetElement->getOption('target_type')) {
-            $type = $this->targetElement->getOption('target_type');
-            $this->targetElement->setObject(new $type());
+        if ($this->targetElement instanceof InputFilterProviderFieldset) {
+            if ($this->targetElement->getOption('target_type')) {
+                $type = $this->targetElement->getOption('target_type');
+                $this->targetElement->setObject(new $type());
+            }
         }
         return clone $this->targetElement;
     }

--- a/src/Element/Collection.php
+++ b/src/Element/Collection.php
@@ -15,11 +15,13 @@ use Laminas\Stdlib\Exception\InvalidArgumentException;
 use Traversable;
 
 use function assert;
+use function class_exists;
 use function count;
 use function gettype;
 use function is_array;
 use function is_int;
 use function is_object;
+use function is_string;
 use function iterator_to_array;
 use function max;
 use function sprintf;
@@ -535,8 +537,8 @@ class Collection extends Fieldset
     {
         assert($this->targetElement !== null);
         if ($this->targetElement instanceof InputFilterProviderFieldset) {
-            if ($this->targetElement->getOption('target_type')) {
-                $type = $this->targetElement->getOption('target_type');
+            if (null !== ($type = $this->targetElement->getOption('target_type'))) {
+                assert(is_string($type) && class_exists($type));
                 $this->targetElement->setObject(new $type());
             }
         }

--- a/src/Element/Collection.php
+++ b/src/Element/Collection.php
@@ -163,7 +163,7 @@ class Collection extends Fieldset
      * Set the object used by the hydrator
      * In this case the "object" is a collection of objects
      *
-     * @param  iterable $object
+     * @param iterable $object
      * @return $this
      * @throws Exception\InvalidArgumentException
      */
@@ -533,6 +533,10 @@ class Collection extends Fieldset
     protected function createNewTargetElementInstance(): ElementInterface
     {
         assert($this->targetElement !== null);
+        if ($this->targetElement->getOption('target_type')) {
+            $type = $this->targetElement->getOption('target_type');
+            $this->targetElement->setObject(new $type());
+        }
         return clone $this->targetElement;
     }
 

--- a/test/Annotation/AbstractBuilderTestCase.php
+++ b/test/Annotation/AbstractBuilderTestCase.php
@@ -299,7 +299,7 @@ abstract class AbstractBuilderTestCase extends TestCase
         self::assertInstanceOf(EntityObjectPropertyHydrator::class, $entity->child[1]);
     }
 
-    protected function validateEntityFilterSpec(array $filterSpec)
+    protected function validateEntityFilterSpec(array $filterSpec): void
     {
         self::assertArrayHasKey('username', $filterSpec);
         self::assertArrayHasKey('password', $filterSpec);

--- a/test/Annotation/AbstractBuilderTestCase.php
+++ b/test/Annotation/AbstractBuilderTestCase.php
@@ -32,6 +32,7 @@ use LaminasTest\Form\TestAsset\Annotation\InputFilterInput;
 use PHPUnit\Framework\TestCase;
 use Throwable;
 
+use function count;
 use function getenv;
 
 abstract class AbstractBuilderTestCase extends TestCase
@@ -261,7 +262,44 @@ abstract class AbstractBuilderTestCase extends TestCase
         self::assertTrue($target->has('username'));
         self::assertTrue($target->has('password'));
         self::assertInstanceOf(InputFilterProviderFieldset::class, $target);
-        $filterSpec = $target->getInputFilterSpecification();
+        $this->validateEntityFilterSpec($target->getInputFilterSpecification());
+    }
+
+    public function testAllowsComposingMultipleChildEntitiesWithEntityBind(): void
+    {
+        $entity  = new TestAsset\Annotation\EntityComposingMultipleEntitiesObjectPropertyHydrator();
+        $builder = $this->createBuilder();
+        $form    = $builder->createForm($entity);
+
+        self::assertTrue($form->has('child'));
+        $child = $form->get('child');
+        self::assertInstanceOf(Collection::class, $child);
+        $target = $child->getTargetElement();
+        self::assertInstanceOf(FieldsetInterface::class, $target);
+        self::assertTrue($target->has('username'));
+        self::assertTrue($target->has('password'));
+        self::assertInstanceOf(InputFilterProviderFieldset::class, $target);
+        $this->validateEntityFilterSpec($target->getInputFilterSpecification());
+
+        self::assertNull($entity->child);
+        $form->bind($entity);
+        $form->setData([
+            'child' => [
+                '0' => ['password' => 'email@test.com', 'username' => 'user'],
+                '1' => ['password' => 'email2@test.com', 'username' => 'user2'],
+            ],
+        ]);
+        self::assertTrue($form->isValid());
+        self::assertNotNull($entity->child);
+        self::assertEquals(2, count($entity->child));
+        self::assertInstanceOf(Entity::class, $entity->child[0]);
+        self::assertEquals('email@test.com', $entity->child[0]->password);
+        self::assertEquals('user', $entity->child[0]->username);
+        self::assertInstanceOf(Entity::class, $entity->child[1]);
+    }
+
+    protected function validateEntityFilterSpec(array $filterSpec)
+    {
         self::assertArrayHasKey('username', $filterSpec);
         self::assertArrayHasKey('password', $filterSpec);
         $usernameFilterSpec = $filterSpec['username'];

--- a/test/Annotation/AbstractBuilderTestCase.php
+++ b/test/Annotation/AbstractBuilderTestCase.php
@@ -26,6 +26,7 @@ use Laminas\Validator\ValidatorChain;
 use LaminasTest\Form\ErrorHandler;
 use LaminasTest\Form\TestAsset;
 use LaminasTest\Form\TestAsset\Annotation\Entity;
+use LaminasTest\Form\TestAsset\Annotation\EntityObjectPropertyHydrator;
 use LaminasTest\Form\TestAsset\Annotation\Form;
 use LaminasTest\Form\TestAsset\Annotation\InputFilter;
 use LaminasTest\Form\TestAsset\Annotation\InputFilterInput;
@@ -292,10 +293,10 @@ abstract class AbstractBuilderTestCase extends TestCase
         self::assertTrue($form->isValid());
         self::assertNotNull($entity->child);
         self::assertEquals(2, count($entity->child));
-        self::assertInstanceOf(Entity::class, $entity->child[0]);
+        self::assertInstanceOf(EntityObjectPropertyHydrator::class, $entity->child[0]);
         self::assertEquals('email@test.com', $entity->child[0]->password);
         self::assertEquals('user', $entity->child[0]->username);
-        self::assertInstanceOf(Entity::class, $entity->child[1]);
+        self::assertInstanceOf(EntityObjectPropertyHydrator::class, $entity->child[1]);
     }
 
     protected function validateEntityFilterSpec(array $filterSpec)

--- a/test/TestAsset/Annotation/EntityComposingMultipleEntitiesObjectPropertyHydrator.php
+++ b/test/TestAsset/Annotation/EntityComposingMultipleEntitiesObjectPropertyHydrator.php
@@ -16,7 +16,7 @@ use Laminas\Hydrator\ObjectPropertyHydrator;
 class EntityComposingMultipleEntitiesObjectPropertyHydrator
 {
     /**
-     * @var null|Entity
+     * @var null|list<EntityObjectPropertyHydrator>
      * @Annotation\ComposedObject("LaminasTest\Form\TestAsset\Annotation\EntityObjectPropertyHydrator", isCollection=true)
      */
     #[Annotation\ComposedObject(
@@ -24,5 +24,5 @@ class EntityComposingMultipleEntitiesObjectPropertyHydrator
         isCollection: true,
         options: ['create_new_objects' => true]
     )]
-    public $child;
+    public ?array $child = null;
 }

--- a/test/TestAsset/Annotation/EntityComposingMultipleEntitiesObjectPropertyHydrator.php
+++ b/test/TestAsset/Annotation/EntityComposingMultipleEntitiesObjectPropertyHydrator.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Form\TestAsset\Annotation;
+
+use Laminas\Form\Annotation;
+use Laminas\Hydrator\ObjectPropertyHydrator;
+
+/**
+ * @Annotation\Name("hierarchical")
+ * @Annotation\Hydrator("Laminas\Hydrator\ObjectPropertyHydrator")
+ */
+#[Annotation\Name("hierarchical")]
+#[Annotation\Hydrator(ObjectPropertyHydrator::class)]
+class EntityComposingMultipleEntitiesObjectPropertyHydrator
+{
+    /**
+     * @var null|Entity
+     * @Annotation\ComposedObject("LaminasTest\Form\TestAsset\Annotation\EntityObjectPropertyHydrator", isCollection=true)
+     */
+    #[Annotation\ComposedObject(
+        EntityObjectPropertyHydrator::class,
+        isCollection: true,
+        options: ['create_new_objects' => true]
+    )]
+    public $child;
+}

--- a/test/TestAsset/Annotation/EntityObjectPropertyHydrator.php
+++ b/test/TestAsset/Annotation/EntityObjectPropertyHydrator.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Form\TestAsset\Annotation;
+
+use Laminas\Form\Annotation;
+use Laminas\Hydrator\ObjectPropertyHydrator;
+
+/**
+ * @Annotation\Hydrator("Laminas\Hydrator\ObjectPropertyHydrator")
+ */
+#[Annotation\Hydrator(ObjectPropertyHydrator::class)]
+class EntityObjectPropertyHydrator extends Entity
+{
+}


### PR DESCRIPTION
Update to include target type in collection element spec built from annotation to later be used to create new element

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | yes/no
| New Feature   | no
| RFC           | yes/no
| QA            | yes

### Description

As described in issue #33 , collection has empty bounded nested objects, while iterating thru the data the method  createNewTargetElementInstance is called to retrieve a new instance of the element, but as the Object is null when trying to hydrate the element the result is an array of nulls in the collection

Added test case testAllowsComposingMultipleChildEntitiesWithEntityBind to validate the result object after binding, with current functionality the assertions to ensure the elements are instances of EntityObjectPropertyHydrator fail as the values of the elements is null