### PR TITLE
Include exclamation point in month element format to prevent time-of-day related bugs

### DIFF
--- a/src/Element/Month.php
+++ b/src/Element/Month.php
@@ -16,7 +16,7 @@ class Month extends AbstractDateTime
      *
      * @var string
      */
-    protected $format = 'Y-m';
+    protected $format = '!Y-m';
 
     /**
      * Seed attributes

--- a/test/Element/MonthTest.php
+++ b/test/Element/MonthTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LaminasTest\Form\Element;
 
 use DateInterval;
+use DateTime;
 use Laminas\Form\Element\Month as MonthElement;
 use Laminas\Validator\DateStep;
 use Laminas\Validator\GreaterThan;
@@ -80,5 +81,12 @@ final class MonthTest extends TestCase
         self::assertArrayHasKey('validators', $inputSpec);
         $monthValidator = $inputSpec['validators'][0];
         self::assertEquals($expected, $monthValidator->isValid($value));
+    }
+
+    public function testTestDayTimeReset(): void
+    {
+        $element = new MonthElement('foo');
+        $date    = DateTime::createFromFormat($element->getFormat(), '2023-01');
+        self::assertEquals($date->format('d H:i:s'), '01 00:00:00');
     }
 }


### PR DESCRIPTION
Update to include exclamation mark in month element format

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description
As described in issue #217, the month element when validated with DateStep on the 31st and with a month value of less than 31 days returns false validation.

Added testTestDayTimeReset test case to validate if month element date is reset

Fixes #217
