### PR TITLE
Cache `stripos()` call result when checking for delimiters in a loop

### DIFF
--- a/src/View/Helper/AbstractFormDateSelect.php
+++ b/src/View/Helper/AbstractFormDateSelect.php
@@ -83,11 +83,12 @@ abstract class AbstractFormDateSelect extends AbstractHelper
 
         $result = [];
         foreach ($pregResult as $value) {
-            if (stripos($value, "'") === false && stripos($value, 'd') !== false) {
+            $noDelimiter = stripos($value, "'") === false;
+            if ($noDelimiter && stripos($value, 'd') !== false) {
                 $result['day'] = $value;
-            } elseif (stripos($value, "'") === false && stripos($value, 'm') !== false) {
+            } elseif ($noDelimiter && stripos($value, 'm') !== false) {
                 $result['month'] = $value;
-            } elseif (stripos($value, "'") === false && stripos($value, 'y') !== false) {
+            } elseif ($noDelimiter && stripos($value, 'y') !== false) {
                 $result['year'] = $value;
             } elseif ($renderDelimiters) {
                 $result[] = str_replace("'", '', $value);

--- a/src/View/Helper/FormDateTimeSelect.php
+++ b/src/View/Helper/FormDateTimeSelect.php
@@ -203,19 +203,20 @@ class FormDateTimeSelect extends AbstractFormDateSelect
 
         $result = [];
         foreach ($pregResult as $value) {
-            if (stripos($value, "'") === false && stripos($value, 'd') !== false) {
+            $noDelimiter = stripos($value, "'") === false;
+            if ($noDelimiter && stripos($value, 'd') !== false) {
                 $result['day'] = $value;
-            } elseif (stripos($value, "'") === false && str_contains($value, 'M')) {
+            } elseif ($noDelimiter && str_contains($value, 'M')) {
                 $result['month'] = $value;
-            } elseif (stripos($value, "'") === false && stripos($value, 'y') !== false) {
+            } elseif ($noDelimiter && stripos($value, 'y') !== false) {
                 $result['year'] = $value;
-            } elseif (stripos($value, "'") === false && stripos($value, 'h') !== false) {
+            } elseif ($noDelimiter && stripos($value, 'h') !== false) {
                 $result['hour'] = $value;
-            } elseif (stripos($value, "'") === false && stripos($value, 'm') !== false) {
+            } elseif ($noDelimiter && stripos($value, 'm') !== false) {
                 $result['minute'] = $value;
-            } elseif (stripos($value, "'") === false && str_contains($value, 's')) {
+            } elseif ($noDelimiter && str_contains($value, 's')) {
                 $result['second'] = $value;
-            } elseif (stripos($value, "'") === false && stripos($value, 'a') !== false) {
+            } elseif ($noDelimiter && stripos($value, 'a') !== false) {
                 // ignore ante/post meridiem marker
                 continue;
             } elseif ($renderDelimiters) {


### PR DESCRIPTION
Avoid calling stripos multiple time for the same result