### PR TITLE
Add validity-tests for form(Date|DateTime|Month)Select formatters option values

### DIFF
--- a/test/View/Helper/AbstractCommonTestCase.php
+++ b/test/View/Helper/AbstractCommonTestCase.php
@@ -22,6 +22,8 @@ abstract class AbstractCommonTestCase extends TestCase
     protected AbstractHelper $helper;
     protected PhpRenderer $renderer;
 
+    protected const NON_NUMERIC_OPTION_REGEX = '/<option value="[^"]*[^"0-9]+[^"]*">/';
+
     protected function setUp(): void
     {
         Doctype::unsetDoctypeRegistry();

--- a/test/View/Helper/FormMonthSelectTest.php
+++ b/test/View/Helper/FormMonthSelectTest.php
@@ -115,4 +115,20 @@ final class FormMonthSelectTest extends AbstractCommonTestCase
 
         self::assertCount(12, $elements[0]->getValueOptions());
     }
+
+    public function testRendersDatesWithArARLocaleContainsSelectOptionsWithOnlyNumericValues(): void
+    {
+        $this->helper->setLocale('ar_AR');
+        $this->helper->setDateType(IntlDateFormatter::LONG);
+
+        $element = new MonthSelect('foo');
+
+        $element->setMinYear(2022);
+        $element->setMaxYear(2023);
+
+        self::assertDoesNotMatchRegularExpression(
+            self::NON_NUMERIC_OPTION_REGEX,
+            $this->helper->render($element)
+        );
+    }
 }


### PR DESCRIPTION
Add PoC tests to prove that current datetime select formatters output non numeric option-values (see issue: https://github.com/laminas/laminas-form/issues/221)

This PR is incomplete as it only add test for month-select option-values. All remaining tests should be added if the alleged bug is recognized to be a real bug. Same goes for related suggested fix (https://github.com/laminas/laminas-form/pull/223)