### PR TITLE
3.x.x add fix for datetime select option values

### DIFF
--- a/src/View/Helper/AbstractFormDateSelect.php
+++ b/src/View/Helper/AbstractFormDateSelect.php
@@ -167,14 +167,6 @@ abstract class AbstractFormDateSelect extends AbstractHelper
      */
     protected function getMonthsOptions(string $pattern): array
     {
-        $keyFormatter   = new IntlDateFormatter(
-            $this->getLocale(),
-            IntlDateFormatter::NONE,
-            IntlDateFormatter::NONE,
-            null,
-            null,
-            'MM'
-        );
         $valueFormatter = new IntlDateFormatter(
             $this->getLocale(),
             IntlDateFormatter::NONE,
@@ -187,7 +179,7 @@ abstract class AbstractFormDateSelect extends AbstractHelper
 
         $result = [];
         for ($month = 1; $month <= 12; $month++) {
-            $key          = $keyFormatter->format($date->getTimestamp());
+            $key          = $date->format('m');
             $value        = $valueFormatter->format($date->getTimestamp());
             $result[$key] = $value;
 

--- a/test/View/Helper/AbstractCommonTestCase.php
+++ b/test/View/Helper/AbstractCommonTestCase.php
@@ -22,6 +22,8 @@ abstract class AbstractCommonTestCase extends TestCase
     protected AbstractHelper $helper;
     protected PhpRenderer $renderer;
 
+    protected const NON_NUMERIC_OPTION_REGEX = '/<option value="[^"]*[^"0-9]+[^"]*">/';
+
     protected function setUp(): void
     {
         Doctype::unsetDoctypeRegistry();

--- a/test/View/Helper/FormDateTimeSelectTest.php
+++ b/test/View/Helper/FormDateTimeSelectTest.php
@@ -299,4 +299,21 @@ XML,
             '<html>' . $this->helper->render($element) . '</html>'
         );
     }
+
+    public function testRendersDatesWithArARLocaleContainsOnlyOptionsWithNumericValues(): void
+    {
+        $this->helper->setLocale('ar_AR');
+        $this->helper->setDateType(IntlDateFormatter::LONG);
+        $this->helper->setTimeType(IntlDateFormatter::LONG);
+
+        $element = new DateTimeSelect('foo');
+
+        $element->setMinYear(2022);
+        $element->setMaxYear(2023);
+
+        self::assertDoesNotMatchRegularExpression(
+            self::NON_NUMERIC_OPTION_REGEX,
+            $this->helper->render($element)
+        );
+    }
 }

--- a/test/View/Helper/FormMonthSelectTest.php
+++ b/test/View/Helper/FormMonthSelectTest.php
@@ -115,4 +115,20 @@ final class FormMonthSelectTest extends AbstractCommonTestCase
 
         self::assertCount(12, $elements[0]->getValueOptions());
     }
+
+    public function testRendersDatesWithArARLocaleContainsSelectOptionsWithOnlyNumericValues(): void
+    {
+        $this->helper->setLocale('ar_AR');
+        $this->helper->setDateType(IntlDateFormatter::LONG);
+
+        $element = new MonthSelect('foo');
+
+        $element->setMinYear(2022);
+        $element->setMaxYear(2023);
+
+        self::assertDoesNotMatchRegularExpression(
+            self::NON_NUMERIC_OPTION_REGEX,
+            $this->helper->render($element)
+        );
+    }
 }


### PR DESCRIPTION
PoC specific fix for test introduced in https://github.com/laminas/laminas-form/pull/222. (see issue https://github.com/laminas/laminas-form/issues/221)

The fix is incomplete. Fixes should be applied to all other selects (day, hour, minute, second).

Differently from other select components, the year select always outputs english digits for years. I believe we should format years option-labels (array-values) as well, while keeping numeric option-values (array-keys)