### PR TITLE
3.13.x ensure numeric expression in datetime select option value for any locale

### DIFF
--- a/src/View/Helper/AbstractFormDateSelect.php
+++ b/src/View/Helper/AbstractFormDateSelect.php
@@ -167,14 +167,6 @@ abstract class AbstractFormDateSelect extends AbstractHelper
      */
     protected function getMonthsOptions(string $pattern): array
     {
-        $keyFormatter   = new IntlDateFormatter(
-            $this->getLocale(),
-            IntlDateFormatter::NONE,
-            IntlDateFormatter::NONE,
-            null,
-            null,
-            'MM'
-        );
         $valueFormatter = new IntlDateFormatter(
             $this->getLocale(),
             IntlDateFormatter::NONE,
@@ -187,7 +179,7 @@ abstract class AbstractFormDateSelect extends AbstractHelper
 
         $result = [];
         for ($month = 1; $month <= 12; $month++) {
-            $key          = $keyFormatter->format($date->getTimestamp());
+            $key          = $date->format('m');
             $value        = $valueFormatter->format($date->getTimestamp());
             $result[$key] = $value;
 

--- a/src/View/Helper/FormDateSelect.php
+++ b/src/View/Helper/FormDateSelect.php
@@ -122,7 +122,7 @@ class FormDateSelect extends AbstractFormDateSelect
         $result = [];
         for ($day = 1; $day <= 31; $day++) {
             $key          = $date->format('d');
-            $value        = $valueFormatter->format($date->getTimestamp());
+            $value        = $valueFormatter->format($date);
             $result[$key] = $value;
 
             $date->modify('+1 day');

--- a/src/View/Helper/FormDateSelect.php
+++ b/src/View/Helper/FormDateSelect.php
@@ -109,14 +109,6 @@ class FormDateSelect extends AbstractFormDateSelect
      */
     protected function getDaysOptions(string $pattern): array
     {
-        $keyFormatter   = new IntlDateFormatter(
-            $this->getLocale(),
-            IntlDateFormatter::NONE,
-            IntlDateFormatter::NONE,
-            null,
-            null,
-            'dd'
-        );
         $valueFormatter = new IntlDateFormatter(
             $this->getLocale(),
             IntlDateFormatter::NONE,
@@ -129,7 +121,7 @@ class FormDateSelect extends AbstractFormDateSelect
 
         $result = [];
         for ($day = 1; $day <= 31; $day++) {
-            $key          = $keyFormatter->format($date->getTimestamp());
+            $key          = $date->format('d');
             $value        = $valueFormatter->format($date->getTimestamp());
             $result[$key] = $value;
 

--- a/src/View/Helper/FormDateTimeSelect.php
+++ b/src/View/Helper/FormDateTimeSelect.php
@@ -235,14 +235,6 @@ class FormDateTimeSelect extends AbstractFormDateSelect
      */
     protected function getDaysOptions(string $pattern): array
     {
-        $keyFormatter   = new IntlDateFormatter(
-            $this->getLocale(),
-            IntlDateFormatter::NONE,
-            IntlDateFormatter::NONE,
-            null,
-            null,
-            'dd'
-        );
         $valueFormatter = new IntlDateFormatter(
             $this->getLocale(),
             IntlDateFormatter::NONE,
@@ -255,7 +247,7 @@ class FormDateTimeSelect extends AbstractFormDateSelect
 
         $result = [];
         for ($day = 1; $day <= 31; $day++) {
-            $key          = $keyFormatter->format($date->getTimestamp());
+            $key          = $date->format('d');
             $value        = $valueFormatter->format($date->getTimestamp());
             $result[$key] = $value;
 
@@ -273,14 +265,6 @@ class FormDateTimeSelect extends AbstractFormDateSelect
      */
     protected function getHoursOptions(string $pattern): array
     {
-        $keyFormatter   = new IntlDateFormatter(
-            $this->getLocale(),
-            IntlDateFormatter::NONE,
-            IntlDateFormatter::NONE,
-            null,
-            null,
-            'HH'
-        );
         $valueFormatter = new IntlDateFormatter(
             $this->getLocale(),
             IntlDateFormatter::NONE,
@@ -293,7 +277,7 @@ class FormDateTimeSelect extends AbstractFormDateSelect
 
         $result = [];
         for ($hour = 1; $hour <= 24; $hour++) {
-            $key          = $keyFormatter->format($date);
+            $key          = $date->format('H');
             $value        = $valueFormatter->format($date);
             $result[$key] = $value;
 
@@ -311,14 +295,6 @@ class FormDateTimeSelect extends AbstractFormDateSelect
      */
     protected function getMinutesOptions(string $pattern): array
     {
-        $keyFormatter   = new IntlDateFormatter(
-            $this->getLocale(),
-            IntlDateFormatter::NONE,
-            IntlDateFormatter::NONE,
-            null,
-            null,
-            'mm'
-        );
         $valueFormatter = new IntlDateFormatter(
             $this->getLocale(),
             IntlDateFormatter::NONE,
@@ -331,7 +307,7 @@ class FormDateTimeSelect extends AbstractFormDateSelect
 
         $result = [];
         for ($min = 1; $min <= 60; $min++) {
-            $key          = $keyFormatter->format($date);
+            $key          = $date->format('i');
             $value        = $valueFormatter->format($date);
             $result[$key] = $value;
 
@@ -349,14 +325,6 @@ class FormDateTimeSelect extends AbstractFormDateSelect
      */
     protected function getSecondsOptions(string $pattern): array
     {
-        $keyFormatter   = new IntlDateFormatter(
-            $this->getLocale(),
-            IntlDateFormatter::NONE,
-            IntlDateFormatter::NONE,
-            null,
-            null,
-            'ss'
-        );
         $valueFormatter = new IntlDateFormatter(
             $this->getLocale(),
             IntlDateFormatter::NONE,
@@ -369,7 +337,7 @@ class FormDateTimeSelect extends AbstractFormDateSelect
 
         $result = [];
         for ($sec = 1; $sec <= 60; $sec++) {
-            $key          = $keyFormatter->format($date);
+            $key          = $date->format('s');
             $value        = $valueFormatter->format($date);
             $result[$key] = $value;
 

--- a/src/View/Helper/FormDateTimeSelect.php
+++ b/src/View/Helper/FormDateTimeSelect.php
@@ -276,7 +276,7 @@ class FormDateTimeSelect extends AbstractFormDateSelect
         $date           = new DateTime('1970-01-01 00:00:00');
 
         $result = [];
-        for ($hour = 1; $hour <= 24; $hour++) {
+        for ($hour = 0; $hour <= 23; $hour++) {
             $key          = $date->format('H');
             $value        = $valueFormatter->format($date);
             $result[$key] = $value;
@@ -306,7 +306,7 @@ class FormDateTimeSelect extends AbstractFormDateSelect
         $date           = new DateTime('1970-01-01 00:00:00');
 
         $result = [];
-        for ($min = 1; $min <= 60; $min++) {
+        for ($min = 0; $min <= 59; $min++) {
             $key          = $date->format('i');
             $value        = $valueFormatter->format($date);
             $result[$key] = $value;
@@ -336,7 +336,7 @@ class FormDateTimeSelect extends AbstractFormDateSelect
         $date           = new DateTime('1970-01-01 00:00:00');
 
         $result = [];
-        for ($sec = 1; $sec <= 60; $sec++) {
+        for ($sec = 0; $sec <= 59; $sec++) {
             $key          = $date->format('s');
             $value        = $valueFormatter->format($date);
             $result[$key] = $value;

--- a/src/View/Helper/FormDateTimeSelect.php
+++ b/src/View/Helper/FormDateTimeSelect.php
@@ -248,7 +248,7 @@ class FormDateTimeSelect extends AbstractFormDateSelect
         $result = [];
         for ($day = 1; $day <= 31; $day++) {
             $key          = $date->format('d');
-            $value        = $valueFormatter->format($date->getTimestamp());
+            $value        = $valueFormatter->format($date);
             $result[$key] = $value;
 
             $date->modify('+1 day');

--- a/test/View/Helper/FormDateTimeSelectTest.php
+++ b/test/View/Helper/FormDateTimeSelectTest.php
@@ -309,6 +309,9 @@ XML,
 
         $availableLocales = IntlCalendar::getAvailableLocales();
 
+        self::assertContains('en', $availableLocales);
+        self::assertContains('ar', $availableLocales);
+
         foreach ($availableLocales as $locale) {
             $this->helper->setLocale($locale);
             $this->helper->setDateType(IntlDateFormatter::SHORT);

--- a/test/View/Helper/FormDateTimeSelectTest.php
+++ b/test/View/Helper/FormDateTimeSelectTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace LaminasTest\Form\View\Helper;
 
+use IntlCalendar;
 use IntlDateFormatter;
 use Laminas\Form\Element\DateTimeSelect;
 use Laminas\Form\Exception\DomainException;
@@ -298,5 +299,24 @@ final class FormDateTimeSelectTest extends AbstractCommonTestCase
 XML,
             '<html>' . $this->helper->render($element) . '</html>'
         );
+    }
+
+    public function testRendersDatesOnlyWithNumericValuesInSelectOptions(): void
+    {
+        $element = new DateTimeSelect('foo');
+        $element->setMinYear(2023);
+        $element->setMaxYear(2023);
+
+        $availableLocales = IntlCalendar::getAvailableLocales();
+
+        foreach ($availableLocales as $locale) {
+            $this->helper->setLocale($locale);
+            $this->helper->setDateType(IntlDateFormatter::SHORT);
+            self::assertDoesNotMatchRegularExpression(
+                '/<option value="[^"]*[^0-9"]+[^"]*">/',
+                $this->helper->render($element),
+                "Option value with locale={$locale} contains non numeric characters!"
+            );
+        }
     }
 }


### PR DESCRIPTION
Possible fix for https://github.com/laminas/laminas-form/issues/221


Note 1:
To speed-up the test case, maybe we could limit the range of values in it.

Note 2:
Also changed the loop limits for hours (0-23), minutes(0-59), seconds(0-59) as they make more sense than 1-24 and 1-60.
The loop only increments the `$date` instance, the loop index is not used (it was in my previous implementation with `sprintf`, I missed that and ended with weird results)

Note(Q) 3:
Any reason for not having `FormDateTimeSelect` inherit from `FormDateSelect` thus inheriting the `getDaysOptions()` method?