### PR TITLE
3.13.x datetime select get elements

### DIFF
--- a/src/Element/DateTimeSelect.php
+++ b/src/Element/DateTimeSelect.php
@@ -12,6 +12,7 @@ use Laminas\Form\FormInterface;
 use Laminas\Validator\Date as DateValidator;
 use Laminas\Validator\ValidatorInterface;
 
+use function array_merge;
 use function is_array;
 use function is_string;
 use function sprintf;
@@ -109,6 +110,15 @@ class DateTimeSelect extends DateSelect
     public function getSecondElement(): Select
     {
         return $this->secondElement;
+    }
+
+    public function getElements(): array
+    {
+        return array_merge(parent::getElements(), [
+            $this->hourElement,
+            $this->minuteElement,
+            $this->secondElement,
+        ]);
     }
 
     /**

--- a/test/View/Helper/FormDateTimeSelectTest.php
+++ b/test/View/Helper/FormDateTimeSelectTest.php
@@ -7,6 +7,7 @@ namespace LaminasTest\Form\View\Helper;
 use IntlCalendar;
 use IntlDateFormatter;
 use Laminas\Form\Element\DateTimeSelect;
+use Laminas\Form\Element\Select;
 use Laminas\Form\Exception\DomainException;
 use Laminas\Form\View\Helper\FormDateTimeSelect as FormDateTimeSelectHelper;
 
@@ -321,5 +322,26 @@ XML,
                 "Option value with locale={$locale} contains non numeric characters!"
             );
         }
+    }
+
+    public function testGetElements(): void
+    {
+        $element = new DateTimeSelect('foo');
+        $this->helper->render($element);
+
+        $elements = $element->getElements();
+        self::assertCount(6, $elements);
+
+        foreach ($elements as $childElement) {
+            self::assertInstanceOf(Select::class, $childElement);
+        }
+
+        self::assertCount(24, $elements[3]->getValueOptions());
+        self::assertCount(60, $elements[4]->getValueOptions());
+        self::assertCount(60, $elements[5]->getValueOptions());
+
+        self::assertContains($element->getHourElement(), $elements);
+        self::assertContains($element->getSecondElement(), $elements);
+        self::assertContains($element->getMinuteElement(), $elements);
     }
 }


### PR DESCRIPTION
Make sure that `DateTimeSelect::getElements()` returns all its sub `Select` elements