### PR TITLE
3.13.x intl lowercase m for minute

### DIFF
--- a/src/View/Helper/FormDateTimeSelect.php
+++ b/src/View/Helper/FormDateTimeSelect.php
@@ -212,7 +212,7 @@ class FormDateTimeSelect extends AbstractFormDateSelect
                 $result['year'] = $value;
             } elseif ($noDelimiter && stripos($value, 'h') !== false) {
                 $result['hour'] = $value;
-            } elseif ($noDelimiter && strpos($value, 'm') !== false) {
+            } elseif ($noDelimiter && str_contains($value, 'm')) {
                 $result['minute'] = $value;
             } elseif ($noDelimiter && str_contains($value, 's')) {
                 $result['second'] = $value;

--- a/src/View/Helper/FormDateTimeSelect.php
+++ b/src/View/Helper/FormDateTimeSelect.php
@@ -212,7 +212,7 @@ class FormDateTimeSelect extends AbstractFormDateSelect
                 $result['year'] = $value;
             } elseif ($noDelimiter && stripos($value, 'h') !== false) {
                 $result['hour'] = $value;
-            } elseif ($noDelimiter && stripos($value, 'm') !== false) {
+            } elseif ($noDelimiter && strpos($value, 'm') !== false) {
                 $result['minute'] = $value;
             } elseif ($noDelimiter && str_contains($value, 's')) {
                 $result['second'] = $value;


### PR DESCRIPTION
The unicode symbol for minute is lowercase 'm' so using `str_contains` or `strpos` is more appropriate

see: https://www.unicode.org/reports/tr35/tr35-dates.html#dfst-minute
see: https://unicode-org.github.io/icu/userguide/format_parse/datetime/#date-field-symbol-table