### PR TITLE
Checkbox: allow `$uncheckedValue` to be nullable to distinguish unset property from empty string and zero string

### DIFF
--- a/src/Element/Checkbox.php
+++ b/src/Element/Checkbox.php
@@ -26,7 +26,7 @@ class Checkbox extends Element implements InputProviderInterface
     /** @var bool */
     protected $useHiddenElement = true;
 
-    /** @var string */
+    /** @var null|string */
     protected $uncheckedValue = '0';
 
     /** @var string */
@@ -83,7 +83,7 @@ class Checkbox extends Element implements InputProviderInterface
      *
      * @return $this
      */
-    public function setUncheckedValue(string $uncheckedValue)
+    public function setUncheckedValue(?string $uncheckedValue)
     {
         $this->uncheckedValue = $uncheckedValue;
         return $this;
@@ -92,7 +92,7 @@ class Checkbox extends Element implements InputProviderInterface
     /**
      * Get the value to use when checkbox is unchecked
      */
-    public function getUncheckedValue(): string
+    public function getUncheckedValue(): ?string
     {
         return $this->uncheckedValue;
     }

--- a/src/Element/MultiCheckbox.php
+++ b/src/Element/MultiCheckbox.php
@@ -29,8 +29,8 @@ class MultiCheckbox extends Checkbox
     /** @var bool */
     protected $useHiddenElement = false;
 
-    /** @var string */
-    protected $uncheckedValue = '';
+    /** @var null|string */
+    protected $uncheckedValue;
 
     /** @var array */
     protected $valueOptions = [];

--- a/src/View/Helper/FormMultiCheckbox.php
+++ b/src/View/Helper/FormMultiCheckbox.php
@@ -54,9 +54,9 @@ class FormMultiCheckbox extends FormInput
     /**
      * The unchecked value used when "UseHiddenElement" is turned on
      *
-     * @var string
+     * @var null|string
      */
-    protected $uncheckedValue = '';
+    protected $uncheckedValue;
 
     /**
      * Form input helper instance
@@ -243,7 +243,7 @@ class FormMultiCheckbox extends FormInput
     {
         $closingBracket = $this->getInlineClosingBracket();
 
-        $uncheckedValue = $element->getUncheckedValue() ?: $this->uncheckedValue;
+        $uncheckedValue = $element->getUncheckedValue() ?? $this->uncheckedValue;
 
         $hiddenAttributes = [
             'name'  => $element->getName(),
@@ -354,7 +354,7 @@ class FormMultiCheckbox extends FormInput
      *
      * @return $this
      */
-    public function setUncheckedValue(string $value)
+    public function setUncheckedValue(?string $value)
     {
         $this->uncheckedValue = $value;
         return $this;
@@ -363,7 +363,7 @@ class FormMultiCheckbox extends FormInput
     /**
      * Returns the unchecked value used when "UseHiddenElement" is turned on.
      */
-    public function getUncheckedValue(): string
+    public function getUncheckedValue(): ?string
     {
         return $this->uncheckedValue;
     }

--- a/test/View/Helper/FormMultiCheckboxTest.php
+++ b/test/View/Helper/FormMultiCheckboxTest.php
@@ -341,7 +341,7 @@ final class FormMultiCheckboxTest extends AbstractCommonTestCase
     public function testGetUncheckedValueReturnsDefaultEmptyString(): void
     {
         $uncheckedValue = $this->helper->getUncheckedValue();
-        self::assertSame('', $uncheckedValue);
+        self::assertNull($uncheckedValue);
     }
 
     public function testGetUncheckedValueSetToFoo(): void
@@ -424,6 +424,19 @@ final class FormMultiCheckboxTest extends AbstractCommonTestCase
     {
         $element = $this->getElement();
         $element->setUseHiddenElement(true);
+
+        $markup = $this->helper->render($element);
+
+        $expectedElement = '<input type="hidden" name="foo" value="">';
+        self::assertStringContainsString($expectedElement, $markup);
+
+        $element->setUncheckedValue('');
+
+        $markup = $this->helper->render($element);
+
+        $expectedElement = '<input type="hidden" name="foo" value="">';
+        self::assertStringContainsString($expectedElement, $markup);
+
         $element->setUncheckedValue('0');
 
         $markup = $this->helper->render($element);

--- a/test/View/Helper/FormMultiCheckboxTest.php
+++ b/test/View/Helper/FormMultiCheckboxTest.php
@@ -419,4 +419,16 @@ final class FormMultiCheckboxTest extends AbstractCommonTestCase
 
         self::assertEmpty($this->helper->render($element));
     }
+
+    public function testRendersZeroAsUncheckedValueOfElement(): void
+    {
+        $element = $this->getElement();
+        $element->setUseHiddenElement(true);
+        $element->setUncheckedValue('0');
+
+        $markup = $this->helper->render($element);
+
+        $expectedElement = '<input type="hidden" name="foo" value="0">';
+        self::assertStringContainsString($expectedElement, $markup);
+    }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

This PR adds a failing test to showcase issue #241