### PR TITLE
Improve type inference for element attributes

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.13.0@a0a9c27630bcf8301ee78cb06741d2907d8c9fef">
+<files psalm-version="5.15.0@5c774aca4746caf3d239d9c8cadb9f882ca29352">
   <file src="src/Annotation/AbstractBuilder.php">
     <InvalidArrayOffset>
       <code><![CDATA[$params['elementSpec']['spec']['type']]]></code>
@@ -552,9 +552,6 @@
       <code><![CDATA[$inputSpec['validators']]]></code>
       <code><![CDATA[$inputSpec['validators']]]></code>
     </PossiblyUndefinedArrayOffset>
-    <UndefinedInterfaceMethod>
-      <code>getValidator</code>
-    </UndefinedInterfaceMethod>
   </file>
   <file src="test/Element/MonthSelectTest.php">
     <PossiblyInvalidArrayAccess>
@@ -601,6 +598,14 @@
     </UndefinedMethod>
   </file>
   <file src="test/Element/MultiCheckboxTest.php">
+    <InvalidArgument>
+      <code><![CDATA[[
+            'options' => [
+                'a' => 'A',
+                'b' => 'B',
+            ],
+        ]]]></code>
+    </InvalidArgument>
     <PossiblyInvalidArrayAccess>
       <code><![CDATA[$inputSpec['validators'][0]]]></code>
       <code><![CDATA[$inputSpec['validators'][0]]]></code>
@@ -689,6 +694,12 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="test/Element/SelectTest.php">
+    <InvalidArgument>
+      <code><![CDATA[[
+            'multiple' => true,
+            'options'  => $valueOptions,
+        ]]]></code>
+    </InvalidArgument>
     <PossiblyInvalidArrayAccess>
       <code><![CDATA[$inputSpec['validators'][0]]]></code>
       <code><![CDATA[$inputSpec['validators'][0]]]></code>
@@ -1101,9 +1112,6 @@
     <InvalidArgument>
       <code>$element</code>
     </InvalidArgument>
-    <PossiblyNullArgument>
-      <code><![CDATA[$element->getAttribute($attribute)]]></code>
-    </PossiblyNullArgument>
   </file>
   <file src="test/View/Helper/FormCaptchaTest.php">
     <PossiblyFalseArgument>
@@ -1120,28 +1128,10 @@
       <code>setView</code>
     </DeprecatedMethod>
   </file>
-  <file src="test/View/Helper/FormColorTest.php">
-    <PossiblyNullArgument>
-      <code><![CDATA[$element->getAttribute($attribute)]]></code>
-    </PossiblyNullArgument>
-  </file>
-  <file src="test/View/Helper/FormDateTest.php">
-    <PossiblyNullArgument>
-      <code><![CDATA[$element->getAttribute($attribute)]]></code>
-    </PossiblyNullArgument>
-  </file>
-  <file src="test/View/Helper/FormDateTimeLocalTest.php">
-    <PossiblyNullArgument>
-      <code><![CDATA[$element->getAttribute($attribute)]]></code>
-    </PossiblyNullArgument>
-  </file>
   <file src="test/View/Helper/FormDateTimeTest.php">
     <DeprecatedClass>
       <code>new FormDateTimeHelper()</code>
     </DeprecatedClass>
-    <PossiblyNullArgument>
-      <code><![CDATA[$element->getAttribute($attribute)]]></code>
-    </PossiblyNullArgument>
   </file>
   <file src="test/View/Helper/FormElementTest.php">
     <PossiblyInvalidMethodCall>
@@ -1154,104 +1144,14 @@
       <code>getHash</code>
     </UndefinedInterfaceMethod>
   </file>
-  <file src="test/View/Helper/FormEmailTest.php">
-    <PossiblyNullArgument>
-      <code><![CDATA[$element->getAttribute($attribute)]]></code>
-    </PossiblyNullArgument>
-  </file>
-  <file src="test/View/Helper/FormFileTest.php">
-    <PossiblyNullArgument>
-      <code><![CDATA[$element->getAttribute($attribute)]]></code>
-    </PossiblyNullArgument>
-  </file>
-  <file src="test/View/Helper/FormHiddenTest.php">
-    <PossiblyNullArgument>
-      <code><![CDATA[$element->getAttribute($attribute)]]></code>
-    </PossiblyNullArgument>
-  </file>
-  <file src="test/View/Helper/FormImageTest.php">
-    <PossiblyNullArgument>
-      <code><![CDATA[$element->getAttribute($attribute)]]></code>
-    </PossiblyNullArgument>
-  </file>
-  <file src="test/View/Helper/FormInputTest.php">
-    <PossiblyNullArgument>
-      <code><![CDATA[$element->getAttribute($attribute)]]></code>
-    </PossiblyNullArgument>
-  </file>
   <file src="test/View/Helper/FormLabelTest.php">
     <InvalidArgument>
       <code>$element</code>
     </InvalidArgument>
   </file>
-  <file src="test/View/Helper/FormMonthTest.php">
-    <PossiblyNullArgument>
-      <code><![CDATA[$element->getAttribute($attribute)]]></code>
-    </PossiblyNullArgument>
-  </file>
-  <file src="test/View/Helper/FormNumberTest.php">
-    <PossiblyNullArgument>
-      <code><![CDATA[$element->getAttribute($attribute)]]></code>
-    </PossiblyNullArgument>
-  </file>
-  <file src="test/View/Helper/FormPasswordTest.php">
-    <PossiblyNullArgument>
-      <code><![CDATA[$element->getAttribute($attribute)]]></code>
-    </PossiblyNullArgument>
-  </file>
-  <file src="test/View/Helper/FormRangeTest.php">
-    <PossiblyNullArgument>
-      <code><![CDATA[$element->getAttribute($attribute)]]></code>
-    </PossiblyNullArgument>
-  </file>
-  <file src="test/View/Helper/FormResetTest.php">
-    <PossiblyNullArgument>
-      <code><![CDATA[$element->getAttribute($attribute)]]></code>
-    </PossiblyNullArgument>
-  </file>
   <file src="test/View/Helper/FormRowTest.php">
     <PossiblyInvalidFunctionCall>
       <code>$escapeHelper($label)</code>
     </PossiblyInvalidFunctionCall>
-  </file>
-  <file src="test/View/Helper/FormSearchTest.php">
-    <PossiblyNullArgument>
-      <code><![CDATA[$element->getAttribute($attribute)]]></code>
-    </PossiblyNullArgument>
-  </file>
-  <file src="test/View/Helper/FormSubmitTest.php">
-    <PossiblyNullArgument>
-      <code><![CDATA[$element->getAttribute($attribute)]]></code>
-    </PossiblyNullArgument>
-  </file>
-  <file src="test/View/Helper/FormTelTest.php">
-    <PossiblyNullArgument>
-      <code><![CDATA[$element->getAttribute($attribute)]]></code>
-    </PossiblyNullArgument>
-  </file>
-  <file src="test/View/Helper/FormTextTest.php">
-    <PossiblyNullArgument>
-      <code><![CDATA[$element->getAttribute($attribute)]]></code>
-    </PossiblyNullArgument>
-  </file>
-  <file src="test/View/Helper/FormTextareaTest.php">
-    <PossiblyNullArgument>
-      <code><![CDATA[$element->getAttribute($attribute)]]></code>
-    </PossiblyNullArgument>
-  </file>
-  <file src="test/View/Helper/FormTimeTest.php">
-    <PossiblyNullArgument>
-      <code><![CDATA[$element->getAttribute($attribute)]]></code>
-    </PossiblyNullArgument>
-  </file>
-  <file src="test/View/Helper/FormUrlTest.php">
-    <PossiblyNullArgument>
-      <code><![CDATA[$element->getAttribute($attribute)]]></code>
-    </PossiblyNullArgument>
-  </file>
-  <file src="test/View/Helper/FormWeekTest.php">
-    <PossiblyNullArgument>
-      <code><![CDATA[$element->getAttribute($attribute)]]></code>
-    </PossiblyNullArgument>
   </file>
 </files>

--- a/src/Element.php
+++ b/src/Element.php
@@ -293,23 +293,14 @@ class Element implements
         return $this->label;
     }
 
-    /**
-     * Set the attributes to use with the label
-     *
-     * @param array<string, mixed> $labelAttributes
-     * @return $this
-     */
+    /** @inheritDoc */
     public function setLabelAttributes(array $labelAttributes)
     {
         $this->labelAttributes = $labelAttributes;
         return $this;
     }
 
-    /**
-     * Get the attributes to use with the label
-     *
-     * @return array<string, mixed>
-     */
+    /** @inheritDoc */
     public function getLabelAttributes(): array
     {
         return $this->labelAttributes;

--- a/src/Element.php
+++ b/src/Element.php
@@ -9,6 +9,7 @@ use Laminas\Stdlib\InitializableInterface;
 use Traversable;
 
 use function array_key_exists;
+use function assert;
 use function is_string;
 
 class Element implements
@@ -87,7 +88,10 @@ class Element implements
      */
     public function getName(): ?string
     {
-        return $this->getAttribute('name');
+        $name = $this->getAttribute('name');
+        assert(is_string($name) || $name === null);
+
+        return $name;
     }
 
     /**

--- a/src/Element.php
+++ b/src/Element.php
@@ -17,19 +17,19 @@ class Element implements
     InitializableInterface,
     LabelAwareInterface
 {
-    /** @var array  */
+    /** @var array<string, scalar|null>  */
     protected $attributes = [];
 
     /** @var null|string */
     protected $label;
 
-    /** @var array */
+    /** @var array<string, scalar|null> */
     protected $labelAttributes = [];
 
     /**
      * Label specific options
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $labelOptions = [];
 
@@ -158,12 +158,7 @@ class Element implements
         return $this;
     }
 
-    /**
-     * Set a single element attribute
-     *
-     * @param  mixed  $value
-     * @return $this
-     */
+    /** @inheritDoc */
     public function setAttribute(string $key, $value)
     {
         // Do not include the value in the list of attributes
@@ -175,11 +170,7 @@ class Element implements
         return $this;
     }
 
-    /**
-     * Retrieve a single element attribute
-     *
-     * @return mixed|null
-     */
+    /** @inheritDoc */
     public function getAttribute(string $key)
     {
         if (! isset($this->attributes[$key])) {
@@ -209,11 +200,7 @@ class Element implements
     }
 
     /**
-     * Set many attributes at once
-     *
-     * Implementation will decide if this will overwrite or merge.
-     *
-     * @return $this
+     * @inheritDoc
      * @throws Exception\InvalidArgumentException
      */
     public function setAttributes(iterable $arrayOrTraversable)
@@ -224,9 +211,7 @@ class Element implements
         return $this;
     }
 
-    /**
-     * Retrieve all attributes at once
-     */
+    /** @inheritDoc */
     public function getAttributes(): array
     {
         return $this->attributes;
@@ -235,7 +220,7 @@ class Element implements
     /**
      * Remove many attributes at once
      *
-     * @param array $keys
+     * @param list<string> $keys
      * @return $this
      */
     public function removeAttributes(array $keys)
@@ -307,7 +292,7 @@ class Element implements
     /**
      * Set the attributes to use with the label
      *
-     * @param array $labelAttributes
+     * @param array<string, mixed> $labelAttributes
      * @return $this
      */
     public function setLabelAttributes(array $labelAttributes)
@@ -319,7 +304,7 @@ class Element implements
     /**
      * Get the attributes to use with the label
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function getLabelAttributes(): array
     {

--- a/src/Element/AbstractDateTime.php
+++ b/src/Element/AbstractDateTime.php
@@ -106,7 +106,7 @@ abstract class AbstractDateTime extends Element implements InputProviderInterfac
 
         if (
             isset($this->attributes['min'])
-            && $this->valueIsValidDateTimeFormat($this->attributes['min'])
+            && $this->valueIsValidDateTimeFormat((string) $this->attributes['min'])
         ) {
             $validators[] = new GreaterThanValidator([
                 'min'       => $this->attributes['min'],
@@ -114,19 +114,19 @@ abstract class AbstractDateTime extends Element implements InputProviderInterfac
             ]);
         } elseif (
             isset($this->attributes['min'])
-            && ! $this->valueIsValidDateTimeFormat($this->attributes['min'])
+            && ! $this->valueIsValidDateTimeFormat((string) $this->attributes['min'])
         ) {
             throw new InvalidArgumentException(sprintf(
                 '%1$s expects "min" to conform to %2$s; received "%3$s"',
                 __METHOD__,
                 $this->format,
-                $this->attributes['min']
+                (string) $this->attributes['min']
             ));
         }
 
         if (
             isset($this->attributes['max'])
-            && $this->valueIsValidDateTimeFormat($this->attributes['max'])
+            && $this->valueIsValidDateTimeFormat((string) $this->attributes['max'])
         ) {
             $validators[] = new LessThanValidator([
                 'max'       => $this->attributes['max'],
@@ -134,13 +134,13 @@ abstract class AbstractDateTime extends Element implements InputProviderInterfac
             ]);
         } elseif (
             isset($this->attributes['max'])
-            && ! $this->valueIsValidDateTimeFormat($this->attributes['max'])
+            && ! $this->valueIsValidDateTimeFormat((string) $this->attributes['max'])
         ) {
             throw new InvalidArgumentException(sprintf(
                 '%1$s expects "max" to conform to %2$s; received "%3$s"',
                 __METHOD__,
                 $this->format,
-                $this->attributes['max']
+                (string) $this->attributes['max']
             ));
         }
         if (

--- a/src/Element/Button.php
+++ b/src/Element/Button.php
@@ -8,11 +8,7 @@ use Laminas\Form\Element;
 
 class Button extends Element
 {
-    /**
-     * Seed attributes
-     *
-     * @var array
-     */
+    /** @var array<string, scalar|null>  */
     protected $attributes = [
         'type' => 'button',
     ];

--- a/src/Element/Checkbox.php
+++ b/src/Element/Checkbox.php
@@ -11,11 +11,7 @@ use Laminas\Validator\ValidatorInterface;
 
 class Checkbox extends Element implements InputProviderInterface
 {
-    /**
-     * Seed attributes
-     *
-     * @var array
-     */
+    /** @var array<string, scalar|null>  */
     protected $attributes = [
         'type' => 'checkbox',
     ];

--- a/src/Element/Color.php
+++ b/src/Element/Color.php
@@ -13,11 +13,7 @@ use Laminas\Validator\ValidatorInterface;
 
 class Color extends Element implements InputProviderInterface
 {
-    /**
-     * Seed attributes
-     *
-     * @var array
-     */
+    /** @var array<string, scalar|null>  */
     protected $attributes = [
         'type' => 'color',
     ];

--- a/src/Element/Csrf.php
+++ b/src/Element/Csrf.php
@@ -16,11 +16,7 @@ use function assert;
 
 class Csrf extends Element implements InputProviderInterface, ElementPrepareAwareInterface
 {
-    /**
-     * Seed attributes
-     *
-     * @var array
-     */
+    /** @var array<string, scalar|null>  */
     protected $attributes = [
         'type' => 'hidden',
     ];
@@ -103,6 +99,8 @@ class Csrf extends Element implements InputProviderInterface, ElementPrepareAwar
      * Override: get attributes
      *
      * Seeds 'value' attribute with validator hash
+     *
+     * @inheritDoc
      */
     public function getAttributes(): array
     {

--- a/src/Element/Date.php
+++ b/src/Element/Date.php
@@ -14,11 +14,7 @@ use function date;
 
 class Date extends DateTimeElement
 {
-    /**
-     * Seed attributes
-     *
-     * @var array
-     */
+    /** @var array<string, scalar|null>  */
     protected $attributes = [
         'type' => 'date',
     ];

--- a/src/Element/DateSelect.php
+++ b/src/Element/DateSelect.php
@@ -64,7 +64,7 @@ class DateSelect extends MonthSelect
     /**
      * Get both the year and month elements
      *
-     * @return array
+     * @return list<Select>
      */
     public function getElements(): array
     {
@@ -74,6 +74,7 @@ class DateSelect extends MonthSelect
     /**
      * Set the day attributes
      *
+     * @param array<string, scalar|null> $dayAttributes
      * @return $this
      */
     public function setDayAttributes(array $dayAttributes)
@@ -85,7 +86,7 @@ class DateSelect extends MonthSelect
     /**
      * Get the day attributes
      *
-     * @return array
+     * @return array<string, scalar|null>
      */
     public function getDayAttributes(): array
     {

--- a/src/Element/DateTime.php
+++ b/src/Element/DateTime.php
@@ -11,11 +11,7 @@ namespace Laminas\Form\Element;
  */
 class DateTime extends AbstractDateTime
 {
-    /**
-     * Seed attributes
-     *
-     * @var array
-     */
+    /** @var array<string, scalar|null>  */
     protected $attributes = [
         'type' => 'datetime',
     ];

--- a/src/Element/DateTimeLocal.php
+++ b/src/Element/DateTimeLocal.php
@@ -10,11 +10,7 @@ use Laminas\Validator\ValidatorInterface;
 
 class DateTimeLocal extends AbstractDateTime
 {
-    /**
-     * Seed attributes
-     *
-     * @var array
-     */
+    /** @var array<string, scalar|null>  */
     protected $attributes = [
         'type' => 'datetime-local',
     ];

--- a/src/Element/DateTimeSelect.php
+++ b/src/Element/DateTimeSelect.php
@@ -112,6 +112,7 @@ class DateTimeSelect extends DateSelect
         return $this->secondElement;
     }
 
+    /** @return list<Select> */
     public function getElements(): array
     {
         return array_merge(parent::getElements(), [
@@ -124,6 +125,7 @@ class DateTimeSelect extends DateSelect
     /**
      * Set the hour attributes
      *
+     * @param array<string, scalar|null> $hourAttributes
      * @return $this
      */
     public function setHourAttributes(array $hourAttributes)
@@ -135,7 +137,7 @@ class DateTimeSelect extends DateSelect
     /**
      * Get the hour attributes
      *
-     * @return array
+     * @return array<string, scalar|null>
      */
     public function getHourAttributes(): array
     {
@@ -145,6 +147,7 @@ class DateTimeSelect extends DateSelect
     /**
      * Set the minute attributes
      *
+     * @param array<string, scalar|null> $minuteAttributes
      * @return $this
      */
     public function setMinuteAttributes(array $minuteAttributes)
@@ -156,7 +159,7 @@ class DateTimeSelect extends DateSelect
     /**
      * Get the minute attributes
      *
-     * @return array
+     * @return array<string, scalar|null>
      */
     public function getMinuteAttributes(): array
     {
@@ -166,6 +169,7 @@ class DateTimeSelect extends DateSelect
     /**
      * Set the second attributes
      *
+     * @param array<string, scalar|null> $secondAttributes
      * @return $this
      */
     public function setSecondAttributes(array $secondAttributes)
@@ -177,7 +181,7 @@ class DateTimeSelect extends DateSelect
     /**
      * Get the second attributes
      *
-     * @return array
+     * @return array<string, scalar|null>
      */
     public function getSecondAttributes(): array
     {

--- a/src/Element/Email.php
+++ b/src/Element/Email.php
@@ -13,11 +13,7 @@ use Laminas\Validator\ValidatorInterface;
 
 class Email extends Element implements InputProviderInterface
 {
-    /**
-     * Seed attributes
-     *
-     * @var array
-     */
+    /** @var array<string, scalar|null>  */
     protected $attributes = [
         'type' => 'email',
     ];

--- a/src/Element/File.php
+++ b/src/Element/File.php
@@ -12,11 +12,7 @@ use Laminas\InputFilter\InputProviderInterface;
 
 class File extends Element implements InputProviderInterface, ElementPrepareAwareInterface
 {
-    /**
-     * Seed attributes
-     *
-     * @var array
-     */
+    /** @var array<string, scalar|null>  */
     protected $attributes = [
         'type' => 'file',
     ];

--- a/src/Element/Hidden.php
+++ b/src/Element/Hidden.php
@@ -8,11 +8,7 @@ use Laminas\Form\Element;
 
 class Hidden extends Element
 {
-    /**
-     * Seed attributes
-     *
-     * @var array
-     */
+    /** @var array<string, scalar|null>  */
     protected $attributes = [
         'type' => 'hidden',
     ];

--- a/src/Element/Image.php
+++ b/src/Element/Image.php
@@ -8,11 +8,7 @@ use Laminas\Form\Element;
 
 class Image extends Element
 {
-    /**
-     * Seed attributes
-     *
-     * @var array
-     */
+    /** @var array<string, scalar|null>  */
     protected $attributes = [
         'type' => 'image',
     ];

--- a/src/Element/Month.php
+++ b/src/Element/Month.php
@@ -18,11 +18,7 @@ class Month extends AbstractDateTime
      */
     protected $format = '!Y-m';
 
-    /**
-     * Seed attributes
-     *
-     * @var array
-     */
+    /** @var array<string, scalar|null>  */
     protected $attributes = [
         'type' => 'month',
     ];

--- a/src/Element/MonthSelect.php
+++ b/src/Element/MonthSelect.php
@@ -142,7 +142,7 @@ class MonthSelect extends Element implements InputProviderInterface, ElementPrep
     /**
      * Get both the year and month elements
      *
-     * @return array
+     * @return list<Select>
      */
     public function getElements(): array
     {
@@ -152,6 +152,7 @@ class MonthSelect extends Element implements InputProviderInterface, ElementPrep
     /**
      * Set the month attributes
      *
+     * @param array<string, scalar|null> $monthAttributes
      * @return $this
      */
     public function setMonthAttributes(array $monthAttributes)
@@ -163,7 +164,7 @@ class MonthSelect extends Element implements InputProviderInterface, ElementPrep
     /**
      * Get the month attributes
      *
-     * @return array
+     * @return array<string, scalar|null>
      */
     public function getMonthAttributes(): array
     {
@@ -173,6 +174,7 @@ class MonthSelect extends Element implements InputProviderInterface, ElementPrep
     /**
      * Set the year attributes
      *
+     * @param array<string, scalar|null> $yearAttributes
      * @return $this
      */
     public function setYearAttributes(array $yearAttributes)
@@ -184,7 +186,7 @@ class MonthSelect extends Element implements InputProviderInterface, ElementPrep
     /**
      * Get the year attributes
      *
-     * @return array
+     * @return array<string, scalar|null>
      */
     public function getYearAttributes(): array
     {

--- a/src/Element/MultiCheckbox.php
+++ b/src/Element/MultiCheckbox.php
@@ -11,6 +11,10 @@ use Laminas\Validator\ValidatorInterface;
 
 use function assert;
 use function is_array;
+use function is_iterable;
+use function trigger_error;
+
+use const E_USER_DEPRECATED;
 
 class MultiCheckbox extends Checkbox
 {
@@ -98,9 +102,13 @@ class MultiCheckbox extends Checkbox
     /** @inheritDoc */
     public function setAttribute(string $key, $value)
     {
-        // Do not include the options in the list of attributes
-        // TODO: Deprecate this
-        if ($key === 'options') {
+        /** @psalm-suppress DocblockTypeContradiction */
+        if ($key === 'options' && is_iterable($value)) {
+            trigger_error(
+                'Providing multi-checkbox value options via attributes is deprecated and will be removed in '
+                . 'version 4.0 of this library',
+                E_USER_DEPRECATED,
+            );
             $this->setValueOptions($value);
             return $this;
         }

--- a/src/Element/MultiCheckbox.php
+++ b/src/Element/MultiCheckbox.php
@@ -14,11 +14,7 @@ use function is_array;
 
 class MultiCheckbox extends Checkbox
 {
-    /**
-     * Seed attributes
-     *
-     * @var array
-     */
+    /** @var array<string, scalar|null>  */
     protected $attributes = [
         'type' => 'multi_checkbox',
     ];
@@ -99,12 +95,7 @@ class MultiCheckbox extends Checkbox
         return $this;
     }
 
-    /**
-     * Set a single element attribute
-     *
-     * @param  mixed  $value
-     * @return $this
-     */
+    /** @inheritDoc */
     public function setAttribute(string $key, $value)
     {
         // Do not include the options in the list of attributes

--- a/src/Element/Number.php
+++ b/src/Element/Number.php
@@ -15,11 +15,7 @@ use Laminas\Validator\ValidatorInterface;
 
 class Number extends Element implements InputProviderInterface
 {
-    /**
-     * Seed attributes
-     *
-     * @var array
-     */
+    /** @var array<string, scalar|null>  */
     protected $attributes = [
         'type' => 'number',
     ];

--- a/src/Element/Password.php
+++ b/src/Element/Password.php
@@ -10,11 +10,7 @@ use Laminas\Form\FormInterface;
 
 class Password extends Element implements ElementPrepareAwareInterface
 {
-    /**
-     * Seed attributes
-     *
-     * @var array
-     */
+    /** @var array<string, scalar|null>  */
     protected $attributes = [
         'type' => 'password',
     ];

--- a/src/Element/Radio.php
+++ b/src/Element/Radio.php
@@ -9,11 +9,7 @@ use Laminas\Validator\ValidatorInterface;
 
 class Radio extends MultiCheckbox
 {
-    /**
-     * Seed attributes
-     *
-     * @var array
-     */
+    /** @var array<string, scalar|null>  */
     protected $attributes = [
         'type' => 'radio',
     ];

--- a/src/Element/Range.php
+++ b/src/Element/Range.php
@@ -13,11 +13,7 @@ use Laminas\Validator\ValidatorInterface;
 
 class Range extends NumberElement
 {
-    /**
-     * Seed attributes
-     *
-     * @var array
-     */
+    /** @var array<string, scalar|null>  */
     protected $attributes = [
         'type' => 'range',
     ];

--- a/src/Element/Search.php
+++ b/src/Element/Search.php
@@ -8,11 +8,7 @@ use Laminas\Form\Element;
 
 class Search extends Element
 {
-    /**
-     * Seed attributes
-     *
-     * @var array
-     */
+    /** @var array<string, scalar|null>  */
     protected $attributes = [
         'type' => 'search',
     ];

--- a/src/Element/Select.php
+++ b/src/Element/Select.php
@@ -16,11 +16,7 @@ use function is_array;
 
 class Select extends Element implements InputProviderInterface
 {
-    /**
-     * Seed attributes
-     *
-     * @var array
-     */
+    /** @var array<string, scalar|null>  */
     protected $attributes = [
         'type' => 'select',
     ];
@@ -134,12 +130,7 @@ class Select extends Element implements InputProviderInterface
         return $this;
     }
 
-    /**
-     * Set a single element attribute
-     *
-     * @param  mixed  $value
-     * @return $this
-     */
+    /** @inheritDoc */
     public function setAttribute(string $key, $value)
     {
         // Do not include the options in the list of attributes

--- a/src/Element/Select.php
+++ b/src/Element/Select.php
@@ -13,6 +13,10 @@ use Laminas\Validator\ValidatorInterface;
 
 use function array_key_exists;
 use function is_array;
+use function is_iterable;
+use function trigger_error;
+
+use const E_USER_DEPRECATED;
 
 class Select extends Element implements InputProviderInterface
 {
@@ -133,9 +137,13 @@ class Select extends Element implements InputProviderInterface
     /** @inheritDoc */
     public function setAttribute(string $key, $value)
     {
-        // Do not include the options in the list of attributes
-        // TODO: Deprecate this
-        if ($key === 'options') {
+        /** @psalm-suppress DocblockTypeContradiction */
+        if ($key === 'options' && is_iterable($value)) {
+            trigger_error(
+                'Providing multi-select value options via attributes is deprecated and will be removed in '
+                . 'version 4.0 of this library',
+                E_USER_DEPRECATED,
+            );
             $this->setValueOptions($value);
             return $this;
         }

--- a/src/Element/Submit.php
+++ b/src/Element/Submit.php
@@ -8,11 +8,7 @@ use Laminas\Form\Element;
 
 class Submit extends Element
 {
-    /**
-     * Seed attributes
-     *
-     * @var array
-     */
+    /** @var array<string, scalar|null>  */
     protected $attributes = [
         'type' => 'submit',
     ];

--- a/src/Element/Tel.php
+++ b/src/Element/Tel.php
@@ -13,11 +13,7 @@ use Laminas\Validator\ValidatorInterface;
 
 class Tel extends Element implements InputProviderInterface
 {
-    /**
-     * Seed attributes
-     *
-     * @var array
-     */
+    /** @var array<string, scalar|null>  */
     protected $attributes = [
         'type' => 'tel',
     ];

--- a/src/Element/Text.php
+++ b/src/Element/Text.php
@@ -8,11 +8,7 @@ use Laminas\Form\Element;
 
 class Text extends Element
 {
-    /**
-     * Seed attributes
-     *
-     * @var array
-     */
+    /** @var array<string, scalar|null>  */
     protected $attributes = [
         'type' => 'text',
     ];

--- a/src/Element/Textarea.php
+++ b/src/Element/Textarea.php
@@ -8,11 +8,7 @@ use Laminas\Form\Element;
 
 class Textarea extends Element
 {
-    /**
-     * Seed attributes
-     *
-     * @var array
-     */
+    /** @var array<string, scalar|null>  */
     protected $attributes = [
         'type' => 'textarea',
     ];

--- a/src/Element/Time.php
+++ b/src/Element/Time.php
@@ -12,11 +12,7 @@ use function date;
 
 class Time extends AbstractDateTime
 {
-    /**
-     * Seed attributes
-     *
-     * @var array
-     */
+    /** @var array<string, scalar|null>  */
     protected $attributes = [
         'type' => 'time',
     ];

--- a/src/Element/Url.php
+++ b/src/Element/Url.php
@@ -12,11 +12,7 @@ use Laminas\Validator\ValidatorInterface;
 
 class Url extends Element implements InputProviderInterface
 {
-    /**
-     * Seed attributes
-     *
-     * @var array
-     */
+    /** @var array<string, scalar|null>  */
     protected $attributes = [
         'type' => 'url',
     ];

--- a/src/Element/Week.php
+++ b/src/Element/Week.php
@@ -13,11 +13,7 @@ use Laminas\Validator\ValidatorInterface;
 
 class Week extends AbstractDateTime
 {
-    /**
-     * Seed attributes
-     *
-     * @var array
-     */
+    /** @var array<string, scalar|null>  */
     protected $attributes = [
         'type' => 'week',
     ];

--- a/src/ElementAttributeRemovalInterface.php
+++ b/src/ElementAttributeRemovalInterface.php
@@ -16,6 +16,7 @@ interface ElementAttributeRemovalInterface
     /**
      * Remove many attributes at once
      *
+     * @param list<string> $keys
      * @return $this
      */
     public function removeAttributes(array $keys);

--- a/src/ElementInterface.php
+++ b/src/ElementInterface.php
@@ -52,6 +52,7 @@ interface ElementInterface
     /**
      * Set a single element attribute
      *
+     * @param scalar|null $value
      * @return $this
      */
     public function setAttribute(string $key, mixed $value);
@@ -59,7 +60,7 @@ interface ElementInterface
     /**
      * Retrieve a single element attribute
      *
-     * @return mixed
+     * @return scalar|null
      */
     public function getAttribute(string $key);
 
@@ -73,12 +74,15 @@ interface ElementInterface
      *
      * Implementation will decide if this will overwrite or merge.
      *
+     * @param iterable<string, scalar|null> $arrayOrTraversable
      * @return $this
      */
     public function setAttributes(iterable $arrayOrTraversable);
 
     /**
      * Retrieve all attributes at once
+     *
+     * @return array<string, scalar|null>
      */
     public function getAttributes(): array;
 

--- a/src/Form.php
+++ b/src/Form.php
@@ -26,11 +26,7 @@ use function sprintf;
 
 class Form extends Fieldset implements FormInterface
 {
-    /**
-     * Seed attributes
-     *
-     * @var array
-     */
+    /** @var array<string, scalar|null>  */
     protected $attributes = [
         'method' => 'POST',
     ];

--- a/src/LabelAwareInterface.php
+++ b/src/LabelAwareInterface.php
@@ -21,7 +21,7 @@ interface LabelAwareInterface
     /**
      * Set the attributes to use with the label
      *
-     * @param  array $labelAttributes
+     * @param  array<string, mixed> $labelAttributes
      * @return $this
      */
     public function setLabelAttributes(array $labelAttributes);

--- a/src/LabelAwareInterface.php
+++ b/src/LabelAwareInterface.php
@@ -21,7 +21,7 @@ interface LabelAwareInterface
     /**
      * Set the attributes to use with the label
      *
-     * @param  array<string, mixed> $labelAttributes
+     * @param  array<string, scalar|null> $labelAttributes
      * @return $this
      */
     public function setLabelAttributes(array $labelAttributes);
@@ -29,7 +29,7 @@ interface LabelAwareInterface
     /**
      * Get the attributes to use with the label
      *
-     * @return array
+     * @return array<string, scalar|null>
      */
     public function getLabelAttributes(): array;
 

--- a/src/View/Helper/AbstractHelper.php
+++ b/src/View/Helper/AbstractHelper.php
@@ -292,8 +292,8 @@ abstract class AbstractHelper extends BaseAbstractHelper
     public function getId(ElementInterface $element): ?string
     {
         $id = $element->getAttribute('id');
-        if (null !== $id) {
-            return (string) $id;
+        if (is_string($id) && $id !== '') {
+            return $id;
         }
 
         return $element->getName();

--- a/src/View/Helper/AbstractHelper.php
+++ b/src/View/Helper/AbstractHelper.php
@@ -293,7 +293,7 @@ abstract class AbstractHelper extends BaseAbstractHelper
     {
         $id = $element->getAttribute('id');
         if (null !== $id) {
-            return $id;
+            return (string) $id;
         }
 
         return $element->getName();

--- a/src/View/Helper/FormButton.php
+++ b/src/View/Helper/FormButton.php
@@ -11,6 +11,7 @@ use Laminas\Form\LabelAwareInterface;
 use function gettype;
 use function is_array;
 use function is_object;
+use function is_string;
 use function sprintf;
 use function strtolower;
 
@@ -163,7 +164,7 @@ class FormButton extends FormInput
     protected function getType(ElementInterface $element): string
     {
         $type = $element->getAttribute('type');
-        if (empty($type)) {
+        if (! is_string($type) || $type === '') {
             return 'submit';
         }
 

--- a/src/View/Helper/FormElement.php
+++ b/src/View/Helper/FormElement.php
@@ -20,7 +20,7 @@ class FormElement extends BaseAbstractHelper
     /**
      * Instance map to view helper
      *
-     * @var array<class-string, string>
+     * @var array<class-string<ElementInterface>, string>
      */
     protected $classMap = [
         Element\Button::class         => 'formbutton',
@@ -147,7 +147,7 @@ class FormElement extends BaseAbstractHelper
     /**
      * Add instance class to plugin map
      *
-     * @param class-string $class
+     * @param class-string<ElementInterface> $class
      * @return $this
      */
     public function addClass(string $class, string $plugin)

--- a/src/View/Helper/FormElement.php
+++ b/src/View/Helper/FormElement.php
@@ -20,7 +20,7 @@ class FormElement extends BaseAbstractHelper
     /**
      * Instance map to view helper
      *
-     * @var array
+     * @var array<class-string, string>
      */
     protected $classMap = [
         Element\Button::class         => 'formbutton',
@@ -35,7 +35,7 @@ class FormElement extends BaseAbstractHelper
     /**
      * Type map to view helper
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $typeMap = [
         'checkbox'       => 'formcheckbox',
@@ -147,6 +147,7 @@ class FormElement extends BaseAbstractHelper
     /**
      * Add instance class to plugin map
      *
+     * @param class-string $class
      * @return $this
      */
     public function addClass(string $class, string $plugin)
@@ -189,8 +190,8 @@ class FormElement extends BaseAbstractHelper
     {
         $type = $element->getAttribute('type');
 
-        if (isset($this->typeMap[$type])) {
-            return $this->renderHelper($this->typeMap[$type], $element);
+        if (isset($this->typeMap[(string) $type])) {
+            return $this->renderHelper($this->typeMap[(string) $type], $element);
         }
 
         return null;

--- a/src/View/Helper/FormInput.php
+++ b/src/View/Helper/FormInput.php
@@ -7,6 +7,7 @@ namespace Laminas\Form\View\Helper;
 use Laminas\Form\ElementInterface;
 use Laminas\Form\Exception;
 
+use function is_string;
 use function sprintf;
 use function strtolower;
 
@@ -138,7 +139,7 @@ class FormInput extends AbstractHelper
     protected function getType(ElementInterface $element): string
     {
         $type = $element->getAttribute('type');
-        if (empty($type)) {
+        if (! is_string($type) || $type === '') {
             return 'text';
         }
 

--- a/test/Element/EmailTest.php
+++ b/test/Element/EmailTest.php
@@ -7,6 +7,7 @@ namespace LaminasTest\Form\Element;
 use Laminas\Form\Element\Email as EmailElement;
 use Laminas\Validator\Explode;
 use Laminas\Validator\Regex;
+use Laminas\Validator\ValidatorInterface;
 use PHPUnit\Framework\TestCase;
 
 final class EmailTest extends TestCase
@@ -28,6 +29,7 @@ final class EmailTest extends TestCase
         }
     }
 
+    /** @return list<array{0: array<string, scalar>, 1: list<class-string<ValidatorInterface>>}> */
     public static function emailAttributesDataProvider(): array
     {
         return [
@@ -39,6 +41,8 @@ final class EmailTest extends TestCase
 
     /**
      * @dataProvider emailAttributesDataProvider
+     * @param array<string, scalar> $attributes
+     * @param list<class-string<ValidatorInterface>> $expectedValidators
      */
     public function testProvidesInputSpecificationBasedOnAttributes(array $attributes, array $expectedValidators): void
     {
@@ -47,7 +51,7 @@ final class EmailTest extends TestCase
 
         $inputSpec = $element->getInputSpecification();
         self::assertArrayHasKey('validators', $inputSpec);
-        self::assertIsArray($inputSpec['validators']);
+        self::assertIsArray($inputSpec['validators'] ?? null);
 
         foreach ($inputSpec['validators'] as $i => $validator) {
             $class = $validator::class;

--- a/test/Element/RadioTest.php
+++ b/test/Element/RadioTest.php
@@ -21,13 +21,10 @@ final class RadioTest extends TestCase
     public function testProvidesInputSpecificationThatIncludesValidatorsBasedOnAttributes(bool $useHiddenElement): void
     {
         $element = new RadioElement();
-        $options = [
+        $element->setValueOptions([
             '1' => 'Option 1',
             '2' => 'Option 2',
             '3' => 'Option 3',
-        ];
-        $element->setAttributes([
-            'options' => $options,
         ]);
         $element->setUseHiddenElement($useHiddenElement);
 
@@ -44,6 +41,7 @@ final class RadioTest extends TestCase
         }
     }
 
+    /** @return list<array{0: list<mixed>, 1: array<array-key, mixed>}> */
     public static function radioOptionsDataProvider(): array
     {
         return [
@@ -70,9 +68,7 @@ final class RadioTest extends TestCase
     public function testInArrayValidationOfOptions(array $valueTests, array $options): void
     {
         $element = new RadioElement('my-radio');
-        $element->setAttributes([
-            'options' => $options,
-        ]);
+        $element->setValueOptions($options);
         $inputSpec = $element->getInputSpecification();
         self::assertArrayHasKey('validators', $inputSpec);
         $inArrayValidator = $inputSpec['validators'][0];

--- a/test/FactoryTest.php
+++ b/test/FactoryTest.php
@@ -96,9 +96,9 @@ final class FactoryTest extends TestCase
                         'name' => 'baz',
                     ],
                     'spec'  => [
-                        'attributes' => [
-                            'type'    => 'radio',
-                            'options' => [
+                        'type'    => Form\Element\Radio::class,
+                        'options' => [
+                            'value_options' => [
                                 'foo' => 'Foo Bar',
                                 'bar' => 'Bar Baz',
                             ],
@@ -130,11 +130,12 @@ final class FactoryTest extends TestCase
         self::assertEquals('text', $element->getAttribute('type'));
 
         $element = $fieldset->get('baz');
+        self::assertInstanceOf(Form\Element\Radio::class, $element);
         self::assertEquals('radio', $element->getAttribute('type'));
         self::assertEquals([
             'foo' => 'Foo Bar',
             'bar' => 'Bar Baz',
-        ], $element->getAttribute('options'));
+        ], $element->getValueOptions());
 
         $element = $fieldset->get('bat');
         self::assertEquals('textarea', $element->getAttribute('type'));
@@ -173,9 +174,9 @@ final class FactoryTest extends TestCase
                                     'name' => 'baz',
                                 ],
                                 'spec'  => [
-                                    'attributes' => [
-                                        'type'    => 'radio',
-                                        'options' => [
+                                    'type'    => Form\Element\Radio::class,
+                                    'options' => [
+                                        'value_options' => [
                                             'foo' => 'Foo Bar',
                                             'bar' => 'Bar Baz',
                                         ],
@@ -211,11 +212,12 @@ final class FactoryTest extends TestCase
         self::assertEquals('text', $element->getAttribute('type'));
 
         $element = $fieldset->get('baz');
+        self::assertInstanceOf(Form\Element\Radio::class, $element);
         self::assertEquals('radio', $element->getAttribute('type'));
         self::assertEquals([
             'foo' => 'Foo Bar',
             'bar' => 'Bar Baz',
-        ], $element->getAttribute('options'));
+        ], $element->getValueOptions());
 
         $element = $fieldset->get('bat');
         self::assertEquals('textarea', $element->getAttribute('type'));
@@ -551,9 +553,9 @@ final class FactoryTest extends TestCase
                         'name' => 'baz',
                     ],
                     'spec'  => [
-                        'attributes' => [
-                            'type'    => 'radio',
-                            'options' => [
+                        'type'    => Form\Element\Radio::class,
+                        'options' => [
+                            'value_options' => [
                                 'foo' => 'Foo Bar',
                                 'bar' => 'Bar Baz',
                             ],
@@ -593,9 +595,9 @@ final class FactoryTest extends TestCase
                                     'name' => 'baz',
                                 ],
                                 'spec'  => [
-                                    'attributes' => [
-                                        'type'    => 'radio',
-                                        'options' => [
+                                    'type'    => Form\Element\Radio::class,
+                                    'options' => [
+                                        'value_options' => [
                                             'foo' => 'Foo Bar',
                                             'bar' => 'Bar Baz',
                                         ],
@@ -633,11 +635,12 @@ final class FactoryTest extends TestCase
         self::assertEquals('text', $element->getAttribute('type'));
 
         $element = $form->get('baz');
+        self::assertInstanceOf(Form\Element\Radio::class, $element);
         self::assertEquals('radio', $element->getAttribute('type'));
         self::assertEquals([
             'foo' => 'Foo Bar',
             'bar' => 'Bar Baz',
-        ], $element->getAttribute('options'));
+        ], $element->getValueOptions());
 
         $element = $form->get('bat');
         self::assertEquals('textarea', $element->getAttribute('type'));
@@ -663,11 +666,12 @@ final class FactoryTest extends TestCase
         self::assertEquals('text', $element->getAttribute('type'));
 
         $element = $fieldset->get('baz');
+        self::assertInstanceOf(Form\Element\Radio::class, $element);
         self::assertEquals('radio', $element->getAttribute('type'));
         self::assertEquals([
             'foo' => 'Foo Bar',
             'bar' => 'Bar Baz',
-        ], $element->getAttribute('options'));
+        ], $element->getValueOptions());
 
         $element = $fieldset->get('bat');
         self::assertEquals('textarea', $element->getAttribute('type'));

--- a/test/View/Helper/FormButtonTest.php
+++ b/test/View/Helper/FormButtonTest.php
@@ -200,8 +200,8 @@ final class FormButtonTest extends AbstractCommonTestCase
         $element->setLabel('{button_content}');
         $markup = $this->helper->render($element);
         $expect = match ($attribute) {
-            'value' => sprintf('%s="%s"', $attribute, $element->getValue()),
-            default => sprintf('%s="%s"', $attribute, $element->getAttribute($attribute)),
+            'value' => sprintf('%s="%s"', $attribute, (string) $element->getValue()),
+            default => sprintf('%s="%s"', $attribute, (string) $element->getAttribute($attribute)),
         };
         $this->$assertion($expect, $markup);
     }

--- a/test/View/Helper/FormColorTest.php
+++ b/test/View/Helper/FormColorTest.php
@@ -129,8 +129,8 @@ final class FormColorTest extends AbstractCommonTestCase
         $element = $this->getCompleteElement();
         $markup  = $this->helper->render($element);
         $expect  = match ($attribute) {
-            'value' => sprintf('%s="%s"', $attribute, $element->getValue()),
-            default => sprintf('%s="%s"', $attribute, $element->getAttribute($attribute)),
+            'value' => sprintf('%s="%s"', $attribute, (string) $element->getValue()),
+            default => sprintf('%s="%s"', $attribute, (string) $element->getAttribute($attribute)),
         };
         $this->$assertion($expect, $markup);
     }

--- a/test/View/Helper/FormDateTest.php
+++ b/test/View/Helper/FormDateTest.php
@@ -131,8 +131,8 @@ final class FormDateTest extends AbstractCommonTestCase
         $element = $this->getCompleteElement();
         $markup  = $this->helper->render($element);
         $expect  = match ($attribute) {
-            'value' => sprintf('%s="%s"', $attribute, $element->getValue()),
-            default => sprintf('%s="%s"', $attribute, $element->getAttribute($attribute)),
+            'value' => sprintf('%s="%s"', $attribute, (string) $element->getValue()),
+            default => sprintf('%s="%s"', $attribute, (string) $element->getAttribute($attribute)),
         };
         $this->$assertion($expect, $markup);
     }

--- a/test/View/Helper/FormDateTimeLocalTest.php
+++ b/test/View/Helper/FormDateTimeLocalTest.php
@@ -129,8 +129,8 @@ final class FormDateTimeLocalTest extends AbstractCommonTestCase
         $element = $this->getCompleteElement();
         $markup  = $this->helper->render($element);
         $expect  = match ($attribute) {
-            'value' => sprintf('%s="%s"', $attribute, $element->getValue()),
-            default => sprintf('%s="%s"', $attribute, $element->getAttribute($attribute)),
+            'value' => sprintf('%s="%s"', $attribute, (string) $element->getValue()),
+            default => sprintf('%s="%s"', $attribute, (string) $element->getAttribute($attribute)),
         };
         $this->$assertion($expect, $markup);
     }

--- a/test/View/Helper/FormDateTimeTest.php
+++ b/test/View/Helper/FormDateTimeTest.php
@@ -129,8 +129,8 @@ final class FormDateTimeTest extends AbstractCommonTestCase
         $element = $this->getCompleteElement();
         $markup  = $this->helper->render($element);
         $expect  = match ($attribute) {
-            'value' => sprintf('%s="%s"', $attribute, $element->getValue()),
-            default => sprintf('%s="%s"', $attribute, $element->getAttribute($attribute)),
+            'value' => sprintf('%s="%s"', $attribute, (string) $element->getValue()),
+            default => sprintf('%s="%s"', $attribute, (string) $element->getAttribute($attribute)),
         };
         $this->$assertion($expect, $markup);
     }

--- a/test/View/Helper/FormElementTest.php
+++ b/test/View/Helper/FormElementTest.php
@@ -39,32 +39,33 @@ final class FormElementTest extends TestCase
         $this->helper->setView($this->renderer);
     }
 
+    /** @return array<string, array{0: string}> */
     public static function getInputElements(): array
     {
         return [
-            ['text'],
-            ['password'],
-            ['checkbox'],
-            ['radio'],
-            ['submit'],
-            ['reset'],
-            ['file'],
-            ['hidden'],
-            ['image'],
-            ['button'],
-            ['number'],
-            ['range'],
-            ['date'],
-            ['color'],
-            ['search'],
-            ['tel'],
-            ['email'],
-            ['url'],
-            ['datetime'],
-            ['datetime-local'],
-            ['month'],
-            ['week'],
-            ['time'],
+            'text'           => ['text'],
+            'password'       => ['password'],
+            'checkbox'       => ['checkbox'],
+            'radio'          => ['radio'],
+            'submit'         => ['submit'],
+            'reset'          => ['reset'],
+            'file'           => ['file'],
+            'hidden'         => ['hidden'],
+            'image'          => ['image'],
+            'button'         => ['button'],
+            'number'         => ['number'],
+            'range'          => ['range'],
+            'date'           => ['date'],
+            'color'          => ['color'],
+            'search'         => ['search'],
+            'tel'            => ['tel'],
+            'email'          => ['email'],
+            'url'            => ['url'],
+            'datetime'       => ['datetime'],
+            'datetime-local' => ['datetime-local'],
+            'month'          => ['month'],
+            'week'           => ['week'],
+            'time'           => ['time'],
         ];
     }
 
@@ -73,19 +74,27 @@ final class FormElementTest extends TestCase
      */
     public function testRendersExpectedInputElement(string $type): void
     {
+        $element = new Element('foo');
+
         if ($type === 'radio') {
             $element = new Element\Radio('foo');
-        } elseif ($type === 'checkbox') {
+            $element->setValueOptions(['option' => 'value']);
+        }
+
+        if ($type === 'checkbox') {
             $element = new Element\Checkbox('foo');
-        } elseif ($type === 'select') {
+        }
+
+        if ($type === 'select') {
             $element = new Element\Select('foo');
-        } else {
-            $element = new Element('foo');
+            $element->setValueOptions(['option' => 'value']);
+        }
+
+        if ($type === 'image') {
+            $element->setAttribute('src', '/some-image.png');
         }
 
         $element->setAttribute('type', $type);
-        $element->setAttribute('options', ['option' => 'value']);
-        $element->setAttribute('src', 'http://zend.com/img.png');
         $markup = $this->helper->render($element);
 
         self::assertStringContainsString('<input', $markup);

--- a/test/View/Helper/FormEmailTest.php
+++ b/test/View/Helper/FormEmailTest.php
@@ -131,8 +131,8 @@ final class FormEmailTest extends AbstractCommonTestCase
         $element = $this->getCompleteElement();
         $markup  = $this->helper->render($element);
         $expect  = match ($attribute) {
-            'value' => sprintf('%s="%s"', $attribute, $element->getValue()),
-            default => sprintf('%s="%s"', $attribute, $element->getAttribute($attribute)),
+            'value' => sprintf('%s="%s"', $attribute, (string) $element->getValue()),
+            default => sprintf('%s="%s"', $attribute, (string) $element->getAttribute($attribute)),
         };
         $this->$assertion($expect, $markup);
     }

--- a/test/View/Helper/FormFileTest.php
+++ b/test/View/Helper/FormFileTest.php
@@ -162,8 +162,8 @@ final class FormFileTest extends AbstractCommonTestCase
         $element = $this->getCompleteElement();
         $markup  = $this->helper->render($element);
         $expect  = match ($attribute) {
-            'value' => sprintf('%s="%s"', $attribute, $element->getValue()),
-            default => sprintf('%s="%s"', $attribute, $element->getAttribute($attribute)),
+            'value' => sprintf('%s="%s"', $attribute, (string) $element->getValue()),
+            default => sprintf('%s="%s"', $attribute, (string) $element->getAttribute($attribute)),
         };
         $this->$assertion($expect, $markup);
     }

--- a/test/View/Helper/FormHiddenTest.php
+++ b/test/View/Helper/FormHiddenTest.php
@@ -129,8 +129,8 @@ final class FormHiddenTest extends AbstractCommonTestCase
         $element = $this->getCompleteElement();
         $markup  = $this->helper->render($element);
         $expect  = match ($attribute) {
-            'value' => sprintf('%s="%s"', $attribute, $element->getValue()),
-            default => sprintf('%s="%s"', $attribute, $element->getAttribute($attribute)),
+            'value' => sprintf('%s="%s"', $attribute, (string) $element->getValue()),
+            default => sprintf('%s="%s"', $attribute, (string) $element->getAttribute($attribute)),
         };
         $this->$assertion($expect, $markup);
     }

--- a/test/View/Helper/FormImageTest.php
+++ b/test/View/Helper/FormImageTest.php
@@ -142,8 +142,8 @@ final class FormImageTest extends AbstractCommonTestCase
         $element = $this->getCompleteElement();
         $markup  = $this->helper->render($element);
         $expect  = match ($attribute) {
-            'value' => sprintf('%s="%s"', $attribute, $element->getValue()),
-            default => sprintf('%s="%s"', $attribute, $element->getAttribute($attribute)),
+            'value' => sprintf('%s="%s"', $attribute, (string) $element->getValue()),
+            default => sprintf('%s="%s"', $attribute, (string) $element->getAttribute($attribute)),
         };
         $this->$assertion($expect, $markup);
     }

--- a/test/View/Helper/FormInputTest.php
+++ b/test/View/Helper/FormInputTest.php
@@ -320,8 +320,8 @@ final class FormInputTest extends AbstractCommonTestCase
         $element = $this->getCompleteElement();
         $markup  = $this->helper->render($element);
         $expect  = match ($attribute) {
-            'value' => sprintf(' %s="%s"', $attribute, $element->getValue()),
-            default => sprintf(' %s="%s"', $attribute, $element->getAttribute($attribute)),
+            'value' => sprintf(' %s="%s"', $attribute, (string) $element->getValue()),
+            default => sprintf(' %s="%s"', $attribute, (string) $element->getAttribute($attribute)),
         };
         $this->$assertion($expect, $markup);
     }

--- a/test/View/Helper/FormMonthTest.php
+++ b/test/View/Helper/FormMonthTest.php
@@ -129,8 +129,8 @@ final class FormMonthTest extends AbstractCommonTestCase
         $element = $this->getCompleteElement();
         $markup  = $this->helper->render($element);
         $expect  = match ($attribute) {
-            'value' => sprintf('%s="%s"', $attribute, $element->getValue()),
-            default => sprintf('%s="%s"', $attribute, $element->getAttribute($attribute)),
+            'value' => sprintf('%s="%s"', $attribute, (string) $element->getValue()),
+            default => sprintf('%s="%s"', $attribute, (string) $element->getAttribute($attribute)),
         };
         $this->$assertion($expect, $markup);
     }

--- a/test/View/Helper/FormMultiCheckboxTest.php
+++ b/test/View/Helper/FormMultiCheckboxTest.php
@@ -128,7 +128,7 @@ final class FormMultiCheckboxTest extends AbstractCommonTestCase
     public function testUsesElementValueToDetermineCheckboxStatus(): void
     {
         $element = $this->getElement();
-        $element->setAttribute('value', ['value1', 'value3']);
+        $element->setValue(['value1', 'value3']);
         $markup = $this->helper->render($element);
 
         self::assertMatchesRegularExpression('#value="value1"\s+checked="checked"#', $markup);
@@ -216,14 +216,14 @@ final class FormMultiCheckboxTest extends AbstractCommonTestCase
         $element->setName('codeType');
         $element->setOptions(['label' => 'Code Type']);
         $element->setAttributes([
-            'type'  => 'radio',
-            'value' => ['markdown'],
+            'type' => 'radio',
         ]);
         $element->setValueOptions([
             'Markdown' => 'markdown',
             'HTML'     => 'html',
             'Wiki'     => 'wiki',
         ]);
+        $element->setValue(['markdown']);
 
         $markup = $this->helper->render($element);
         self::assertStringNotContainsString('type="hidden"', $markup);

--- a/test/View/Helper/FormNumberTest.php
+++ b/test/View/Helper/FormNumberTest.php
@@ -129,8 +129,8 @@ final class FormNumberTest extends AbstractCommonTestCase
         $element = $this->getCompleteElement();
         $markup  = $this->helper->render($element);
         $expect  = match ($attribute) {
-            'value' => sprintf('%s="%s"', $attribute, $element->getValue()),
-            default => sprintf('%s="%s"', $attribute, $element->getAttribute($attribute)),
+            'value' => sprintf('%s="%s"', $attribute, (string) $element->getValue()),
+            default => sprintf('%s="%s"', $attribute, (string) $element->getAttribute($attribute)),
         };
         $this->$assertion($expect, $markup);
     }

--- a/test/View/Helper/FormPasswordTest.php
+++ b/test/View/Helper/FormPasswordTest.php
@@ -132,7 +132,7 @@ final class FormPasswordTest extends AbstractCommonTestCase
         $markup  = $this->helper->render($element);
         $expect  = match ($attribute) {
             'value' => sprintf('%s=""', $attribute),
-            default => sprintf('%s="%s"', $attribute, $element->getAttribute($attribute)),
+            default => sprintf('%s="%s"', $attribute, (string) $element->getAttribute($attribute)),
         };
         $this->$assertion($expect, $markup);
     }

--- a/test/View/Helper/FormRadioTest.php
+++ b/test/View/Helper/FormRadioTest.php
@@ -125,7 +125,7 @@ final class FormRadioTest extends AbstractCommonTestCase
     public function testUsesElementValueToDetermineRadioStatus(): void
     {
         $element = $this->getElement();
-        $element->setAttribute('value', ['value1', 'value3']);
+        $element->setValue(['value1', 'value3']);
         $markup = $this->helper->render($element);
 
         self::assertMatchesRegularExpression('#value="value1"\s+checked="checked"#', $markup);

--- a/test/View/Helper/FormRangeTest.php
+++ b/test/View/Helper/FormRangeTest.php
@@ -129,8 +129,8 @@ final class FormRangeTest extends AbstractCommonTestCase
         $element = $this->getCompleteElement();
         $markup  = $this->helper->render($element);
         $expect  = match ($attribute) {
-            'value' => sprintf('%s="%s"', $attribute, $element->getValue()),
-            default => sprintf('%s="%s"', $attribute, $element->getAttribute($attribute)),
+            'value' => sprintf('%s="%s"', $attribute, (string) $element->getValue()),
+            default => sprintf('%s="%s"', $attribute, (string) $element->getAttribute($attribute)),
         };
         $this->$assertion($expect, $markup);
     }

--- a/test/View/Helper/FormResetTest.php
+++ b/test/View/Helper/FormResetTest.php
@@ -131,8 +131,8 @@ final class FormResetTest extends AbstractCommonTestCase
         $element = $this->getCompleteElement();
         $markup  = $this->helper->render($element);
         $expect  = match ($attribute) {
-            'value' => sprintf('%s="%s"', $attribute, $element->getValue()),
-            default => sprintf('%s="%s"', $attribute, $element->getAttribute($attribute)),
+            'value' => sprintf('%s="%s"', $attribute, (string) $element->getValue()),
+            default => sprintf('%s="%s"', $attribute, (string) $element->getAttribute($attribute)),
         };
         $this->$assertion($expect, $markup);
     }

--- a/test/View/Helper/FormRowTest.php
+++ b/test/View/Helper/FormRowTest.php
@@ -121,7 +121,7 @@ final class FormRowTest extends AbstractCommonTestCase
 
         $element = new Element\MultiCheckbox('foo');
         $element->setAttribute('type', 'multi_checkbox');
-        $element->setAttribute('options', $options);
+        $element->setValueOptions($options);
         $element->setLabel('This is a multi-checkbox');
         $markup = $this->helper->render($element);
         self::assertStringContainsString('<fieldset>', $markup);

--- a/test/View/Helper/FormSearchTest.php
+++ b/test/View/Helper/FormSearchTest.php
@@ -131,8 +131,8 @@ final class FormSearchTest extends AbstractCommonTestCase
         $element = $this->getCompleteElement();
         $markup  = $this->helper->render($element);
         $expect  = match ($attribute) {
-            'value' => sprintf('%s="%s"', $attribute, $element->getValue()),
-            default => sprintf('%s="%s"', $attribute, $element->getAttribute($attribute)),
+            'value' => sprintf('%s="%s"', $attribute, (string) $element->getValue()),
+            default => sprintf('%s="%s"', $attribute, (string) $element->getAttribute($attribute)),
         };
         $this->$assertion($expect, $markup);
     }

--- a/test/View/Helper/FormSelectTest.php
+++ b/test/View/Helper/FormSelectTest.php
@@ -85,18 +85,18 @@ final class FormSelectTest extends AbstractCommonTestCase
     public function testCanOnlyMarkSingleOptionAsSelectedIfMultipleAttributeIsDisabled(): void
     {
         $element = $this->getElement();
-        $element->setAttribute('value', ['value1', 'value2']);
+        $element->setValue(['value1', 'value2']);
 
         $this->expectException(DomainException::class);
         $this->expectExceptionMessage('multiple');
-        $markup = $this->helper->render($element);
+        $this->helper->render($element);
     }
 
     public function testCanMarkManyOptionsAsSelectedIfMultipleAttributeIsEnabled(): void
     {
         $element = $this->getElement();
         $element->setAttribute('multiple', true);
-        $element->setAttribute('value', ['value1', 'value2']);
+        $element->setValue(['value1', 'value2']);
         $markup = $this->helper->render($element);
 
         self::assertMatchesRegularExpression('#select .*?multiple="multiple"#', $markup);
@@ -192,7 +192,7 @@ final class FormSelectTest extends AbstractCommonTestCase
     {
         $element = $this->getElement();
         $element->setAttribute('multiple', true);
-        $element->setAttribute('value', ['value1', 'value2']);
+        $element->setValue(['value1', 'value2']);
         $markup = $this->helper->render($element);
         self::assertMatchesRegularExpression('#<select[^>]*?(name="foo\&\#x5B\;\&\#x5D\;")#', $markup);
     }

--- a/test/View/Helper/FormSubmitTest.php
+++ b/test/View/Helper/FormSubmitTest.php
@@ -130,8 +130,8 @@ final class FormSubmitTest extends AbstractCommonTestCase
         $element = $this->getCompleteElement();
         $markup  = $this->helper->render($element);
         $expect  = match ($attribute) {
-            'value' => sprintf('%s="%s"', $attribute, $element->getValue()),
-            default => sprintf('%s="%s"', $attribute, $element->getAttribute($attribute)),
+            'value' => sprintf('%s="%s"', $attribute, (string) $element->getValue()),
+            default => sprintf('%s="%s"', $attribute, (string) $element->getAttribute($attribute)),
         };
         $this->$assertion($expect, $markup);
     }

--- a/test/View/Helper/FormTelTest.php
+++ b/test/View/Helper/FormTelTest.php
@@ -131,8 +131,8 @@ final class FormTelTest extends AbstractCommonTestCase
         $element = $this->getCompleteElement();
         $markup  = $this->helper->render($element);
         $expect  = match ($attribute) {
-            'value' => sprintf('%s="%s"', $attribute, $element->getValue()),
-            default => sprintf('%s="%s"', $attribute, $element->getAttribute($attribute)),
+            'value' => sprintf('%s="%s"', $attribute, (string) $element->getValue()),
+            default => sprintf('%s="%s"', $attribute, (string) $element->getAttribute($attribute)),
         };
         $this->$assertion($expect, $markup);
     }

--- a/test/View/Helper/FormTextTest.php
+++ b/test/View/Helper/FormTextTest.php
@@ -133,8 +133,8 @@ final class FormTextTest extends AbstractCommonTestCase
         $element = $this->getCompleteElement();
         $markup  = $this->helper->render($element);
         $expect  = match ($attribute) {
-            'value' => sprintf('%s="%s"', $attribute, $element->getValue()),
-            default => sprintf('%s="%s"', $attribute, $element->getAttribute($attribute)),
+            'value' => sprintf('%s="%s"', $attribute, (string) $element->getValue()),
+            default => sprintf('%s="%s"', $attribute, (string) $element->getAttribute($attribute)),
         };
         $this->$assertion($expect, $markup);
     }

--- a/test/View/Helper/FormTextareaTest.php
+++ b/test/View/Helper/FormTextareaTest.php
@@ -247,7 +247,7 @@ final class FormTextareaTest extends AbstractCommonTestCase
     ): void {
         $element = $this->getCompleteElement();
         $markup  = $this->helper->render($element);
-        $expect  = sprintf('%s="%s"', $attribute, $element->getAttribute($attribute));
+        $expect  = sprintf('%s="%s"', $attribute, (string) $element->getAttribute($attribute));
         $this->$assertion($expect, $markup);
     }
 

--- a/test/View/Helper/FormTimeTest.php
+++ b/test/View/Helper/FormTimeTest.php
@@ -129,8 +129,8 @@ final class FormTimeTest extends AbstractCommonTestCase
         $element = $this->getCompleteElement();
         $markup  = $this->helper->render($element);
         $expect  = match ($attribute) {
-            'value' => sprintf('%s="%s"', $attribute, $element->getValue()),
-            default => sprintf('%s="%s"', $attribute, $element->getAttribute($attribute)),
+            'value' => sprintf('%s="%s"', $attribute, (string) $element->getValue()),
+            default => sprintf('%s="%s"', $attribute, (string) $element->getAttribute($attribute)),
         };
         $this->$assertion($expect, $markup);
     }

--- a/test/View/Helper/FormUrlTest.php
+++ b/test/View/Helper/FormUrlTest.php
@@ -131,8 +131,8 @@ final class FormUrlTest extends AbstractCommonTestCase
         $element = $this->getCompleteElement();
         $markup  = $this->helper->render($element);
         $expect  = match ($attribute) {
-            'value' => sprintf('%s="%s"', $attribute, $element->getValue()),
-            default => sprintf('%s="%s"', $attribute, $element->getAttribute($attribute)),
+            'value' => sprintf('%s="%s"', $attribute, (string) $element->getValue()),
+            default => sprintf('%s="%s"', $attribute, (string) $element->getAttribute($attribute)),
         };
         $this->$assertion($expect, $markup);
     }

--- a/test/View/Helper/FormWeekTest.php
+++ b/test/View/Helper/FormWeekTest.php
@@ -129,8 +129,8 @@ final class FormWeekTest extends AbstractCommonTestCase
         $element = $this->getCompleteElement();
         $markup  = $this->helper->render($element);
         $expect  = match ($attribute) {
-            'value' => sprintf('%s="%s"', $attribute, $element->getValue()),
-            default => sprintf('%s="%s"', $attribute, $element->getAttribute($attribute)),
+            'value' => sprintf('%s="%s"', $attribute, (string) $element->getValue()),
+            default => sprintf('%s="%s"', $attribute, (string) $element->getAttribute($attribute)),
         };
         $this->$assertion($expect, $markup);
     }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| QA            | yes

### Description

Marks all attribute arrays and iterables as `<string, mixed>` which is slightly better than `<array-key, mixed>`

This is pretty minor stuff, but it really helps in consumer projects running psalm.

I considered that we could have gone for `<string, scalar|null>` but I'm fairly sure there are cases where arrays are accepted, or maybe even iterables at which point, `<string, mixed>` felt like a better middle ground considering `ElementInterface::getAttribute(string $name): mixed`
