### PR TITLE
Improve type inference for MultiCheckbox Value Options

### DIFF
--- a/src/Element/MultiCheckbox.php
+++ b/src/Element/MultiCheckbox.php
@@ -16,6 +16,16 @@ use function trigger_error;
 
 use const E_USER_DEPRECATED;
 
+/**
+ * @psalm-type ValueOptionSpec = array<string, string>|list<array{
+ *     label: non-empty-string,
+ *     value: non-empty-string,
+ *     selected?: bool,
+ *     disabled?: bool,
+ *     attributes?: array<string, scalar|null>,
+ *     label_attributes?: array<string, scalar|null>,
+ * }>
+ */
 class MultiCheckbox extends Checkbox
 {
     /** @var array<string, scalar|null>  */
@@ -32,11 +42,11 @@ class MultiCheckbox extends Checkbox
     /** @var null|string */
     protected $uncheckedValue;
 
-    /** @var array */
+    /** @var ValueOptionSpec */
     protected $valueOptions = [];
 
     /**
-     * @return array
+     * @return ValueOptionSpec
      */
     public function getValueOptions(): array
     {
@@ -44,6 +54,7 @@ class MultiCheckbox extends Checkbox
     }
 
     /**
+     * @param ValueOptionSpec $options
      * @return $this
      */
     public function setValueOptions(array $options)
@@ -61,6 +72,11 @@ class MultiCheckbox extends Checkbox
     }
 
     /**
+     * Unset a value option
+     *
+     * This method will only unset a value option when the element was created with a simple array of key-value pairs
+     * for value options, for example ['value1' => 'label1', 'value2' => 'label2']
+     *
      * @return $this
      */
     public function unsetValueOption(string $key)

--- a/test/StaticAnalysis/MultiCheckboxValueOptions.php
+++ b/test/StaticAnalysis/MultiCheckboxValueOptions.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Form\StaticAnalysis;
+
+use Laminas\Form\Element\MultiCheckbox;
+
+/** @psalm-suppress UnusedClass, UnusedMethod */
+final class MultiCheckboxValueOptions
+{
+    public function checkValueOptionsVariations(): void
+    {
+        $element = new MultiCheckbox('foo');
+        $element->setValueOptions([
+            'a' => 'A',
+            'b' => 'B',
+        ]);
+
+        $element = new MultiCheckbox('foo');
+        $element->setValueOptions([
+            [
+                'label' => 'Foo',
+                'value' => 'Bar',
+            ],
+            [
+                'label'    => 'Foo',
+                'value'    => 'Bar',
+                'disabled' => false,
+            ],
+            [
+                'label'    => 'Foo',
+                'value'    => 'Bar',
+                'disabled' => true,
+                'selected' => true,
+            ],
+            [
+                'label'      => 'Foo',
+                'value'      => 'Bar',
+                'attributes' => [
+                    'readonly'  => true,
+                    'something' => 'else',
+                ],
+            ],
+            [
+                'label'            => 'Foo',
+                'value'            => 'Bar',
+                'label_attributes' => [
+                    'inert' => true,
+                    'class' => 'baz',
+                ],
+            ],
+        ]);
+
+        $element = new MultiCheckbox('foo');
+        $element->setValueOptions([
+            'foo' => 'bar',
+            [
+                'label'            => 'Foo',
+                'value'            => 'Bar',
+                'disabled'         => true,
+                'selected'         => true,
+                'attributes'       => [
+                    'readonly'  => true,
+                    'something' => 'else',
+                ],
+                'label_attributes' => [
+                    'inert' => true,
+                    'class' => 'baz',
+                ],
+            ],
+            'bing' => 'bong',
+        ]);
+    }
+}

--- a/test/View/Helper/FormMultiCheckboxTest.php
+++ b/test/View/Helper/FormMultiCheckboxTest.php
@@ -67,6 +67,8 @@ final class FormMultiCheckboxTest extends AbstractCommonTestCase
         self::assertEquals(3, substr_count($markup, '<label'));
 
         foreach ($options as $value => $label) {
+            self::assertIsString($value);
+            self::assertIsString($label);
             self::assertStringContainsString(sprintf('>%s</label>', $label), $markup);
             self::assertStringContainsString(sprintf('value="%s"', $value), $markup);
         }
@@ -120,6 +122,8 @@ final class FormMultiCheckboxTest extends AbstractCommonTestCase
         self::assertEquals(3, substr_count($markup, '<label'));
 
         foreach ($options as $value => $label) {
+            self::assertIsString($value);
+            self::assertIsString($label);
             self::assertStringContainsString(sprintf('>%s</label>', $label), $markup);
             self::assertStringContainsString(sprintf('value="%s"', $value), $markup);
         }
@@ -157,6 +161,8 @@ final class FormMultiCheckboxTest extends AbstractCommonTestCase
         self::assertEquals(3, substr_count($markup, '<label'));
 
         foreach ($options as $value => $label) {
+            self::assertIsString($value);
+            self::assertIsString($label);
             self::assertStringContainsString(sprintf('<label>%s<', $label), $markup);
         }
     }

--- a/test/View/Helper/FormRadioTest.php
+++ b/test/View/Helper/FormRadioTest.php
@@ -64,6 +64,8 @@ final class FormRadioTest extends AbstractCommonTestCase
         self::assertEquals(3, substr_count($markup, '<label'));
 
         foreach ($options as $value => $label) {
+            self::assertIsString($value);
+            self::assertIsString($label);
             self::assertStringContainsString(sprintf('>%s</label>', $label), $markup);
             self::assertStringContainsString(sprintf('value="%s"', $value), $markup);
         }
@@ -117,6 +119,8 @@ final class FormRadioTest extends AbstractCommonTestCase
         self::assertEquals(3, substr_count($markup, '<label'));
 
         foreach ($options as $value => $label) {
+            self::assertIsString($value);
+            self::assertIsString($label);
             self::assertStringContainsString(sprintf('>%s</label>', $label), $markup);
             self::assertStringContainsString(sprintf('value="%s"', $value), $markup);
         }
@@ -154,6 +158,8 @@ final class FormRadioTest extends AbstractCommonTestCase
         self::assertEquals(3, substr_count($markup, '<label'));
 
         foreach ($options as $value => $label) {
+            self::assertIsString($value);
+            self::assertIsString($label);
             self::assertStringContainsString(sprintf('<label>%s<', $label), $markup);
         }
     }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| QA            | yes

### Description

Minor improvement to the DocBlocks for value options in MultiCheckbox form element - just documents the accepted array shape/types.

Doesn't affect the baseline, or fix any issues, but it's useful docs…