### PR TITLE
Fixes #3 - Element::init is called before Element::setOptions when using Factory but not when using FormElementManager

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -107,7 +107,7 @@ class Factory
         $spec = $this->validateSpecification($spec, __METHOD__);
         $type = $spec['type'] ?? Element::class;
 
-        $element = $this->getFormElementManager()->get($type);
+        $element = $this->getFormElementManager()->get($type, $spec['options'] ?? []);
 
         if ($element instanceof FormInterface) {
             return $this->configureForm($element, $spec);

--- a/test/FactoryTest.php
+++ b/test/FactoryTest.php
@@ -849,4 +849,21 @@ final class FactoryTest extends TestCase
         self::assertInstanceOf(TestAsset\FieldsetWithDependency::class, $targetElement);
         self::assertInstanceOf(InputFilter::class, $targetElement->getDependency());
     }
+
+    public function testSetOptionsShouldBeCalledBeforeInitMethodIsCalled(): void
+    {
+        $values = range(1, 10);
+
+        /** @var TestAsset\SelectElementWithValueOptionsCheck $element */
+        $element = $this->factory->create(
+            [
+                'type' => TestAsset\SelectElementWithValueOptionsCheck::class,
+                'options' => [
+                    'value_options' => $values,
+                ],
+            ]
+        );
+
+        self::assertSame($values, $element->getValueOptions());
+    }
 }

--- a/test/FormElementManagerTest.php
+++ b/test/FormElementManagerTest.php
@@ -121,6 +121,21 @@ final class FormElementManagerTest extends TestCase
         self::assertEquals('bar', $element->getLabel(), 'Specified options in array[options]');
     }
 
+    public function testSetOptionsShouldBeCalledBeforeInitMethodIsCalled(): void
+    {
+        $values = range(1, 10);
+
+        /** @var TestAsset\SelectElementWithValueOptionsCheck $element */
+        $element = $this->manager->get(
+            TestAsset\SelectElementWithValueOptionsCheck::class,
+            [
+                'value_options' => $values,
+            ],
+        );
+
+        self::assertSame($values, $element->getValueOptions());
+    }
+
     /**
      * @group issue-6132
      */

--- a/test/TestAsset/SelectElementWithValueOptionsCheck.php
+++ b/test/TestAsset/SelectElementWithValueOptionsCheck.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Form\TestAsset;
+
+use Laminas\Form\Element\Select;
+
+use function assert;
+
+final class SelectElementWithValueOptionsCheck extends Select
+{
+    public function init(): void
+    {
+        assert($this->valueOptions !== []);
+    }
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Fixes #3: Element::init is called before Element::setOptions when using Zend\Form\Factory but not when using FormElementManager
