### PR TITLE
Allow disabled- and form-Attribute on fieldsets

### DIFF
--- a/src/View/Helper/FormCollection.php
+++ b/src/View/Helper/FormCollection.php
@@ -25,7 +25,9 @@ class FormCollection extends AbstractHelper
      * @var array
      */
     protected $validTagAttributes = [
-        'name' => true,
+        'name'     => true,
+        'disabled' => true,
+        'form'     => true,
     ];
 
     /**

--- a/src/View/Helper/FormCollection.php
+++ b/src/View/Helper/FormCollection.php
@@ -8,7 +8,6 @@ use Laminas\Form\Element\Collection as CollectionElement;
 use Laminas\Form\ElementInterface;
 use Laminas\Form\FieldsetInterface;
 use Laminas\Form\LabelAwareInterface;
-use Laminas\View\Helper\Doctype;
 use Laminas\View\Helper\HelperInterface;
 use RuntimeException;
 
@@ -79,11 +78,6 @@ class FormCollection extends AbstractHelper
      */
     protected $fieldsetHelper;
 
-    private array $doctypesAllowedToHaveNameAttribute = [
-        Doctype::HTML5  => true,
-        Doctype::XHTML5 => true,
-    ];
-
     /**
      * Invoke helper as function
      *
@@ -138,8 +132,12 @@ class FormCollection extends AbstractHelper
         // Every collection is wrapped by a fieldset if needed
         if ($this->shouldWrap) {
             $attributes = $element->getAttributes();
-            if (! isset($this->doctypesAllowedToHaveNameAttribute[$this->getDoctype()])) {
-                unset($attributes['name']);
+            if (! $this->getDoctypeHelper()->isHtml5()) {
+                unset(
+                    $attributes['name'],
+                    $attributes['disabled'],
+                    $attributes['form']
+                );
             }
             $attributesString = $attributes !== [] ? ' ' . $this->createAttributesString($attributes) : '';
 

--- a/test/View/Helper/FormCollectionTest.php
+++ b/test/View/Helper/FormCollectionTest.php
@@ -411,7 +411,6 @@ final class FormCollectionTest extends AbstractCommonTestCase
     public function testForElementHelperNotInstanceOfHelperInterface(): void
     {
         $method = new ReflectionMethod(FormCollectionHelper::class, 'getElementHelper');
-        $method->setAccessible(true);
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage(
@@ -458,8 +457,6 @@ final class FormCollectionTest extends AbstractCommonTestCase
             [Doctype::HTML4_LOOSE,         false],
             [Doctype::HTML4_FRAMESET,      false],
             [Doctype::HTML5,               true],
-            [Doctype::CUSTOM_XHTML,        false],
-            [Doctype::CUSTOM,              false],
         ];
     }
 
@@ -483,7 +480,7 @@ final class FormCollectionTest extends AbstractCommonTestCase
         } elseif ($doctype === Doctype::XHTML5) {
             self::assertStringContainsString('<fieldset name="colors" disabled="disabled">', $markup);
         } else {
-            self::assertStringContainsString('<fieldset disabled="disabled">', $markup);
+            self::assertStringContainsString('<fieldset>', $markup);
         }
     }
 

--- a/test/View/Helper/FormCollectionTest.php
+++ b/test/View/Helper/FormCollectionTest.php
@@ -465,6 +465,7 @@ final class FormCollectionTest extends AbstractCommonTestCase
      */
     public function testRenderCollectionWithDisabledAttribute(
         string $doctype,
+        bool $allowsNameAttribute,
         bool $allowsShortAttribute
     ): void {
         $this->helper->setDoctype($doctype);
@@ -475,10 +476,12 @@ final class FormCollectionTest extends AbstractCommonTestCase
 
         $markup = $this->helper->render($collection);
 
-        if ($allowsShortAttribute) {
-            self::assertStringContainsString('<fieldset name="colors" disabled>', $markup);
-        } elseif ($doctype === Doctype::XHTML5) {
-            self::assertStringContainsString('<fieldset name="colors" disabled="disabled">', $markup);
+        if ($allowsNameAttribute) {
+            if ($allowsShortAttribute) {
+                self::assertStringContainsString('<fieldset name="colors" disabled>', $markup);
+            } else {
+                self::assertStringContainsString('<fieldset name="colors" disabled="disabled">', $markup);
+            }
         } else {
             self::assertStringContainsString('<fieldset>', $markup);
         }
@@ -487,18 +490,66 @@ final class FormCollectionTest extends AbstractCommonTestCase
     public static function provideDoctypesAndPermitFlagForDisabledAttribute(): array
     {
         return [
-            [Doctype::XHTML11,             false],
-            [Doctype::XHTML1_STRICT,       false],
-            [Doctype::XHTML1_TRANSITIONAL, false],
-            [Doctype::XHTML1_FRAMESET,     false],
-            [Doctype::XHTML1_RDFA,         false],
-            [Doctype::XHTML1_RDFA11,       false],
-            [Doctype::XHTML_BASIC1,        false],
-            [Doctype::XHTML5,              false],
-            [Doctype::HTML4_STRICT,        false],
-            [Doctype::HTML4_LOOSE,         false],
-            [Doctype::HTML4_FRAMESET,      false],
-            [Doctype::HTML5,               true],
+            [
+                'doctype'              => Doctype::XHTML11,
+                'allowsNameAttribute'  => false,
+                'allowsShortAttribute' => false,
+            ],
+            [
+                'doctype'              => Doctype::XHTML1_STRICT,
+                'allowsNameAttribute'  => false,
+                'allowsShortAttribute' => false,
+            ],
+            [
+                'doctype'              => Doctype::XHTML1_TRANSITIONAL,
+                'allowsNameAttribute'  => false,
+                'allowsShortAttribute' => false,
+            ],
+            [
+                'doctype'              => Doctype::XHTML1_FRAMESET,
+                'allowsNameAttribute'  => false,
+                'allowsShortAttribute' => false,
+            ],
+            [
+                'doctype'              => Doctype::XHTML1_RDFA,
+                'allowsNameAttribute'  => false,
+                'allowsShortAttribute' => false,
+            ],
+            [
+                'doctype'              => Doctype::XHTML1_RDFA11,
+                'allowsNameAttribute'  => false,
+                'allowsShortAttribute' => false,
+            ],
+            [
+                'doctype'              => Doctype::XHTML_BASIC1,
+                'allowsNameAttribute'  => false,
+                'allowsShortAttribute' => false,
+            ],
+            [
+                'doctype'              => Doctype::XHTML5,
+                'allowsNameAttribute'  => true,
+                'allowsShortAttribute' => false,
+            ],
+            [
+                'doctype'              => Doctype::HTML4_STRICT,
+                'allowsNameAttribute'  => false,
+                'allowsShortAttribute' => false,
+            ],
+            [
+                'doctype'              => Doctype::HTML4_LOOSE,
+                'allowsNameAttribute'  => false,
+                'allowsShortAttribute' => false,
+            ],
+            [
+                'doctype'              => Doctype::HTML4_FRAMESET,
+                'allowsNameAttribute'  => false,
+                'allowsShortAttribute' => false,
+            ],
+            [
+                'doctype'              => Doctype::HTML5,
+                'allowsNameAttribute'  => true,
+                'allowsShortAttribute' => true,
+            ],
         ];
     }
 }

--- a/test/View/Helper/FormCollectionTest.php
+++ b/test/View/Helper/FormCollectionTest.php
@@ -462,4 +462,46 @@ final class FormCollectionTest extends AbstractCommonTestCase
             [Doctype::CUSTOM,              false],
         ];
     }
+
+    /**
+     * @dataProvider provideDoctypesAndPermitFlagForDisabledAttribute
+     */
+    public function testRenderCollectionWithDisabledAttribute(
+        string $doctype,
+        bool $allowsShortAttribute
+    ): void {
+        $this->helper->setDoctype($doctype);
+
+        $form       = $this->getForm();
+        $collection = $form->get('colors');
+        $collection->setAttribute('disabled', true);
+
+        $markup = $this->helper->render($collection);
+
+        if ($allowsShortAttribute) {
+            self::assertStringContainsString('<fieldset name="colors" disabled>', $markup);
+        } elseif ($doctype === Doctype::XHTML5) {
+            self::assertStringContainsString('<fieldset name="colors" disabled="disabled">', $markup);
+        } else {
+            self::assertStringContainsString('<fieldset disabled="disabled">', $markup);
+        }
+    }
+
+    public static function provideDoctypesAndPermitFlagForDisabledAttribute(): array
+    {
+        return [
+            [Doctype::XHTML11,             false],
+            [Doctype::XHTML1_STRICT,       false],
+            [Doctype::XHTML1_TRANSITIONAL, false],
+            [Doctype::XHTML1_FRAMESET,     false],
+            [Doctype::XHTML1_RDFA,         false],
+            [Doctype::XHTML1_RDFA11,       false],
+            [Doctype::XHTML_BASIC1,        false],
+            [Doctype::XHTML5,              false],
+            [Doctype::HTML4_STRICT,        false],
+            [Doctype::HTML4_LOOSE,         false],
+            [Doctype::HTML4_FRAMESET,      false],
+            [Doctype::HTML5,               true],
+        ];
+    }
 }

--- a/test/View/Helper/FormCollectionTest.php
+++ b/test/View/Helper/FormCollectionTest.php
@@ -552,4 +552,43 @@ final class FormCollectionTest extends AbstractCommonTestCase
             ],
         ];
     }
+
+    /**
+     * @dataProvider provideDoctypesAndPermitFlagForFormAttribute
+     */
+    public function testRenderCollectionWithFormAttributeAndDoctypeHtml5(
+        string $doctype,
+        bool $allowsFormAttribute
+    ): void {
+        $this->helper->setDoctype($doctype);
+
+        $form       = $this->getForm();
+        $collection = $form->get('colors');
+        $collection->setAttribute('form', 'foo');
+
+        $markup = $this->helper->render($collection);
+        if ($allowsFormAttribute) {
+            self::assertStringContainsString('<fieldset name="colors" form="foo">', $markup);
+        } else {
+            self::assertStringContainsString('<fieldset>', $markup);
+        }
+    }
+
+    public static function provideDoctypesAndPermitFlagForFormAttribute(): array
+    {
+        return [
+            [Doctype::XHTML11,             false],
+            [Doctype::XHTML1_STRICT,       false],
+            [Doctype::XHTML1_TRANSITIONAL, false],
+            [Doctype::XHTML1_FRAMESET,     false],
+            [Doctype::XHTML1_RDFA,         false],
+            [Doctype::XHTML1_RDFA11,       false],
+            [Doctype::XHTML_BASIC1,        false],
+            [Doctype::XHTML5,              true],
+            [Doctype::HTML4_STRICT,        false],
+            [Doctype::HTML4_LOOSE,         false],
+            [Doctype::HTML4_FRAMESET,      false],
+            [Doctype::HTML5,               true],
+        ];
+    }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

This PR wants to allow the Attributes "disabled" and "form" on fieldsets. This is related to Issue #155.
