### PR TITLE
Fix handling of seconds in the FormDateTimeSelect view helper

### DIFF
--- a/src/Element/Select.php
+++ b/src/Element/Select.php
@@ -321,6 +321,8 @@ class Select extends Element implements InputProviderInterface
 
     /**
      * @return mixed
+     * @param (int|string) $key
+     * @psalm-param array-key $key
      */
     protected function getOptionValue(mixed $key, mixed $optionSpec)
     {

--- a/test/View/Helper/FormDateTimeSelectTest.php
+++ b/test/View/Helper/FormDateTimeSelectTest.php
@@ -349,7 +349,7 @@ XML,
         self::assertContains($element->getMinuteElement(), $elements);
     }
 
-    public function testGetElementsWithSesonds(): void
+    public function testGetElementsWithSeconds(): void
     {
         $element = new DateTimeSelect('foo');
         $element->setShouldShowSeconds(true);

--- a/test/View/Helper/FormDateTimeSelectTest.php
+++ b/test/View/Helper/FormDateTimeSelectTest.php
@@ -449,6 +449,8 @@ XML,
 
         $markup = $this->helper->render($element);
 
-        self::assertStringContainsString('<select name="day">', $markup);
+        self::assertStringContainsString('<select name="hour">', $markup);
+        self::assertStringContainsString('<select name="minute">', $markup);
+        self::assertStringNotContainsString('<select name="second">', $markup);
     }
 }

--- a/test/View/Helper/FormDateTimeSelectTest.php
+++ b/test/View/Helper/FormDateTimeSelectTest.php
@@ -340,6 +340,31 @@ XML,
 
         self::assertCount(24, $elements[3]->getValueOptions());
         self::assertCount(60, $elements[4]->getValueOptions());
+
+        // no value options are added for the second-object, as it should not be rendered
+        self::assertCount(0, $elements[5]->getValueOptions());
+
+        self::assertContains($element->getHourElement(), $elements);
+        self::assertContains($element->getSecondElement(), $elements);
+        self::assertContains($element->getMinuteElement(), $elements);
+    }
+
+    public function testGetElementsWithSesonds(): void
+    {
+        $element = new DateTimeSelect('foo');
+        $element->setShouldShowSeconds(true);
+
+        $this->helper->render($element);
+
+        $elements = $element->getElements();
+        self::assertCount(6, $elements);
+
+        foreach ($elements as $childElement) {
+            self::assertInstanceOf(Select::class, $childElement);
+        }
+
+        self::assertCount(24, $elements[3]->getValueOptions());
+        self::assertCount(60, $elements[4]->getValueOptions());
         self::assertCount(60, $elements[5]->getValueOptions());
 
         self::assertContains($element->getHourElement(), $elements);
@@ -412,5 +437,18 @@ XML,
         $shortMarkup = $helper->__invoke($element, $short, $long);
 
         self::assertNotEquals($longMarkup, $shortMarkup);
+    }
+
+    public function testShortTimeFormatDoesNotProvideSecondPart(): void
+    {
+        $element = new DateTimeSelect('foo');
+        $element->setMinYear(2023);
+        $element->setMaxYear(2023);
+
+        $this->helper->setTimeType(IntlDateFormatter::SHORT);
+
+        $markup = $this->helper->render($element);
+
+        self::assertStringContainsString('<select name="day">', $markup);
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

This PR wants to fix the handling of seconds in the FormDateTimeSelect. This is related to issue #236.
