### PR TITLE
Improve type inference for FormElementManager::get()

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -241,6 +241,9 @@
       <code>Element\DateTime::class</code>
       <code>Element\DateTime::class</code>
     </DeprecatedClass>
+    <LessSpecificReturnStatement>
+      <code>parent::get($name, $options)</code>
+    </LessSpecificReturnStatement>
     <NonInvariantDocblockPropertyType>
       <code>$aliases</code>
       <code>$factories</code>

--- a/src/FormElementManager.php
+++ b/src/FormElementManager.php
@@ -321,9 +321,10 @@ class FormElementManager extends AbstractPluginManager
      * createFromInvokable() will use these and pass them to the instance
      * constructor if not null and a non-empty array.
      *
-     * @param class-string<ElementInterface>|string $name Service name of plugin to retrieve.
+     * @template T of ElementInterface
+     * @param class-string<T>|string $name Service name of plugin to retrieve.
      * @param null|array<mixed> $options Options to use when creating the instance.
-     * @psalm-return ($name is class-string<ElementInterface> ? ElementInterface : mixed)
+     * @psalm-return ($name is class-string<T> ? T : mixed)
      */
     public function get($name, ?array $options = null): mixed
     {

--- a/src/FormElementManager.php
+++ b/src/FormElementManager.php
@@ -324,7 +324,7 @@ class FormElementManager extends AbstractPluginManager
      * @template T of ElementInterface
      * @param class-string<T>|string $name Service name of plugin to retrieve.
      * @param null|array<mixed> $options Options to use when creating the instance.
-     * @psalm-return ($name is class-string<ElementInterface> ? T : ElementInterface)
+     * @return ($name is class-string<ElementInterface> ? T : ElementInterface)
      */
     public function get($name, ?array $options = null): mixed
     {

--- a/src/FormElementManager.php
+++ b/src/FormElementManager.php
@@ -324,7 +324,7 @@ class FormElementManager extends AbstractPluginManager
      * @template T of ElementInterface
      * @param class-string<T>|string $name Service name of plugin to retrieve.
      * @param null|array<mixed> $options Options to use when creating the instance.
-     * @psalm-return ($name is class-string<T> ? T : mixed)
+     * @psalm-return ($name is class-string<ElementInterface> ? T : ElementInterface)
      */
     public function get($name, ?array $options = null): mixed
     {

--- a/test/FormElementManagerTest.php
+++ b/test/FormElementManagerTest.php
@@ -25,6 +25,7 @@ use Throwable;
 
 use function array_pop;
 use function array_shift;
+use function assert;
 use function count;
 use function method_exists;
 use function strtoupper;
@@ -44,6 +45,7 @@ final class FormElementManagerTest extends TestCase
     public function testInjectToFormFactoryAware(): void
     {
         $form = $this->manager->get('Form');
+        assert($form instanceof Form);
         self::assertSame($this->manager, $form->getFormFactory()->getFormElementManager());
     }
 
@@ -59,6 +61,7 @@ final class FormElementManagerTest extends TestCase
             return $form;
         });
         $form = $this->manager->get('my-form');
+        assert($form instanceof Form);
         self::assertSame($factory, $form->getFormFactory());
         self::assertSame($this->manager, $form->getFormFactory()->getFormElementManager());
     }

--- a/test/StaticAnalysis/FormElementManagerType.php
+++ b/test/StaticAnalysis/FormElementManagerType.php
@@ -29,4 +29,9 @@ final class FormElementManagerType
     {
         return $this->manager->get(NewProductForm::class);
     }
+
+    public function getReturnsElementInterfaceWhenGivenInvalidClassStringType(): ElementInterface
+    {
+        return $this->manager->get(self::class);
+    }
 }

--- a/test/StaticAnalysis/FormElementManagerType.php
+++ b/test/StaticAnalysis/FormElementManagerType.php
@@ -7,6 +7,7 @@ namespace LaminasTest\Form\StaticAnalysis;
 use Laminas\Form\Element\Checkbox;
 use Laminas\Form\ElementInterface;
 use Laminas\Form\FormElementManager;
+use LaminasTest\Form\TestAsset\NewProductForm;
 
 final class FormElementManagerType
 {
@@ -22,5 +23,10 @@ final class FormElementManagerType
     public function getReturnsMixedWhenGivenAnAlias(): mixed
     {
         return $this->manager->get('foo');
+    }
+
+    public function getReturnsObjectOfClassWhenGivenFQCN(): NewProductForm
+    {
+        return $this->manager->get(NewProductForm::class);
     }
 }

--- a/test/StaticAnalysis/FormElementManagerType.php
+++ b/test/StaticAnalysis/FormElementManagerType.php
@@ -20,7 +20,7 @@ final class FormElementManagerType
         return $this->manager->get(Checkbox::class);
     }
 
-    public function getReturnsMixedWhenGivenAnAlias(): mixed
+    public function getReturnsElementInterfaceWhenGivenAnAlias(): ElementInterface
     {
         return $this->manager->get('foo');
     }


### PR DESCRIPTION
Currently, if you provide `FormElementManager::get()` with a FQCN, it infers `ElementInterface` instead of the given FQCN. This patch fixes that…

There are some un-related psalm issues from recent patches. Let me know if you want these baselined here
