### PR TITLE
Fix BC break preventing the use of scalar element labels during render

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -295,6 +295,9 @@
       <code>translate</code>
       <code>translate</code>
     </PossiblyNullReference>
+    <RedundantCastGivenDocblockType>
+      <code>(string) $label</code>
+    </RedundantCastGivenDocblockType>
   </file>
   <file src="src/View/Helper/Form.php">
     <DeprecatedMethod>

--- a/src/View/Helper/AbstractHelper.php
+++ b/src/View/Helper/AbstractHelper.php
@@ -561,12 +561,17 @@ abstract class AbstractHelper extends BaseAbstractHelper
     }
 
     /**
-     * translate the label
+     * Translate the label
      *
      * @internal
+     *
+     * @todo Reduce argument to only string in the next major
+     * @param string $label
      */
-    protected function translateLabel(string $label): string
+    protected function translateLabel(int|string|float|bool $label): string
     {
+        $label = (string) $label;
+
         return $this->getTranslator()?->translate($label, $this->getTranslatorTextDomain()) ?? $label;
     }
 

--- a/test/View/Helper/AbstractHelperTest.php
+++ b/test/View/Helper/AbstractHelperTest.php
@@ -5,9 +5,13 @@ declare(strict_types=1);
 namespace LaminasTest\Form\View\Helper;
 
 use Laminas\Escaper\Escaper;
+use Laminas\Form\Element\Select;
 use Laminas\Form\Exception\InvalidArgumentException;
 use Laminas\Form\View\Helper\AbstractHelper;
+use Laminas\Form\View\Helper\FormSelect;
 use Laminas\I18n\Translator\Translator;
+
+use function range;
 
 /**
  * Tests for {@see \Laminas\Form\View\Helper\AbstractHelper}
@@ -235,5 +239,17 @@ final class AbstractHelperTest extends AbstractCommonTestCase
             '',
             $this->helper->createAttributesString(['disabled' => null])
         );
+    }
+
+    public function testThatAnIntegerElementLabelWillBeCastToAString(): void
+    {
+        $select = new Select('some-name');
+        $select->setValueOptions(range(0, 10));
+
+        $helper = new FormSelect();
+
+        $markup = $helper->render($select);
+
+        self::assertStringContainsString('<option value="1">1</option>', $markup);
     }
 }

--- a/test/View/Helper/AbstractHelperTest.php
+++ b/test/View/Helper/AbstractHelperTest.php
@@ -241,6 +241,11 @@ final class AbstractHelperTest extends AbstractCommonTestCase
         );
     }
 
+    /**
+     * @deprecated This test should be removed in 4.0 and string should become a hard requirement for labels
+     *
+     * @covers \Laminas\Form\View\Helper\AbstractHelper::translateLabel
+     */
     public function testThatAnIntegerElementLabelWillBeCastToAString(): void
     {
         $select = new Select('some-name');


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Bugfix        | yes

### Description

#259 introduces a BC break requiring element labels (and select value options) to be `string`. This patch adds a failing test that passes on previous minors.