### PR TITLE
Helper optional renderer consistency

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -3,8 +3,7 @@ name: docs-build
 on:
   release:
     types: [published]
-  repository_dispatch:
-    types: docs-build
+  workflow_dispatch:
 
 jobs:
   build-deploy:
@@ -13,5 +12,5 @@ jobs:
       - name: Build Docs
         uses: laminas/documentation-theme/github-actions/docs@master
         env:
-          "DOCS_DEPLOY_KEY": ${{ secrets.DOCS_DEPLOY_KEY }}
-          "GITHUB_TOKEN": ${{ secrets.GITHUB_TOKEN }}
+          DEPLOY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/composer.lock
+++ b/composer.lock
@@ -164,16 +164,16 @@
         },
         {
             "name": "laminas/laminas-inputfilter",
-            "version": "2.28.0",
+            "version": "2.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-inputfilter.git",
-                "reference": "d6f819d456d89316237d753fb9a6ac0108486f8d"
+                "reference": "82a76f40477c3e399863d13446a5c0187f421775"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-inputfilter/zipball/d6f819d456d89316237d753fb9a6ac0108486f8d",
-                "reference": "d6f819d456d89316237d753fb9a6ac0108486f8d",
+                "url": "https://api.github.com/repos/laminas/laminas-inputfilter/zipball/82a76f40477c3e399863d13446a5c0187f421775",
+                "reference": "82a76f40477c3e399863d13446a5c0187f421775",
                 "shasum": ""
             },
             "require": {
@@ -189,10 +189,10 @@
             "require-dev": {
                 "ext-json": "*",
                 "laminas/laminas-coding-standard": "~2.5.0",
-                "phpunit/phpunit": "^10.4.2",
+                "phpunit/phpunit": "^10.5.5",
                 "psalm/plugin-phpunit": "^0.18.4",
                 "psr/http-message": "^2.0",
-                "vimeo/psalm": "^5.15",
+                "vimeo/psalm": "^5.18",
                 "webmozart/assert": "^1.11"
             },
             "suggest": {
@@ -234,7 +234,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2023-11-02T15:54:27+00:00"
+            "time": "2024-01-10T11:57:06+00:00"
         },
         {
             "name": "laminas/laminas-servicemanager",
@@ -3468,16 +3468,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.5",
+            "version": "10.5.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "ed21115d505b4b4f7dc7b5651464e19a2c7f7856"
+                "reference": "e5c5b397a95cb0db013270a985726fcae93e61b8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/ed21115d505b4b4f7dc7b5651464e19a2c7f7856",
-                "reference": "ed21115d505b4b4f7dc7b5651464e19a2c7f7856",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/e5c5b397a95cb0db013270a985726fcae93e61b8",
+                "reference": "e5c5b397a95cb0db013270a985726fcae93e61b8",
                 "shasum": ""
             },
             "require": {
@@ -3549,7 +3549,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.5"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.7"
             },
             "funding": [
                 {
@@ -3565,7 +3565,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-12-27T15:13:52+00:00"
+            "time": "2024-01-14T16:40:30+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -4767,16 +4767,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.8.0",
+            "version": "3.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "5805f7a4e4958dbb5e944ef1e6edae0a303765e7"
+                "reference": "14f5fff1e64118595db5408e946f3a22c75807f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/5805f7a4e4958dbb5e944ef1e6edae0a303765e7",
-                "reference": "5805f7a4e4958dbb5e944ef1e6edae0a303765e7",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/14f5fff1e64118595db5408e946f3a22c75807f7",
+                "reference": "14f5fff1e64118595db5408e946f3a22c75807f7",
                 "shasum": ""
             },
             "require": {
@@ -4786,11 +4786,11 @@
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
             },
             "bin": [
-                "bin/phpcs",
-                "bin/phpcbf"
+                "bin/phpcbf",
+                "bin/phpcs"
             ],
             "type": "library",
             "extra": {
@@ -4843,7 +4843,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2023-12-08T12:32:31+00:00"
+            "time": "2024-01-11T20:47:48+00:00"
         },
         {
             "name": "symfony/console",
@@ -5619,16 +5619,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "5.18.0",
+            "version": "5.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "b113f3ed0259fd6e212d87c3df80eec95a6abf19"
+                "reference": "06b71be009a6bd6d81b9811855d6629b9fe90e1b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/b113f3ed0259fd6e212d87c3df80eec95a6abf19",
-                "reference": "b113f3ed0259fd6e212d87c3df80eec95a6abf19",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/06b71be009a6bd6d81b9811855d6629b9fe90e1b",
+                "reference": "06b71be009a6bd6d81b9811855d6629b9fe90e1b",
                 "shasum": ""
             },
             "require": {
@@ -5725,7 +5725,7 @@
                 "issues": "https://github.com/vimeo/psalm/issues",
                 "source": "https://github.com/vimeo/psalm"
             },
-            "time": "2023-12-16T09:37:35+00:00"
+            "time": "2024-01-09T21:02:43+00:00"
         },
         {
             "name": "webimpress/coding-standard",

--- a/src/View/Helper/AbstractFormDateSelect.php
+++ b/src/View/Helper/AbstractFormDateSelect.php
@@ -223,11 +223,11 @@ abstract class AbstractFormDateSelect extends AbstractHelper
             return $this->selectHelper;
         }
 
-        if ($this->view && method_exists($this->view, 'plugin')) {
+        if (null !== $this->view && method_exists($this->view, 'plugin')) {
             $this->selectHelper = $this->view->plugin('formselect');
         }
 
-        if (! $this->selectHelper instanceof FormSelect) {
+        if (null === $this->selectHelper) {
             $this->selectHelper = new FormSelect();
         }
 

--- a/src/View/Helper/AbstractFormDateSelect.php
+++ b/src/View/Helper/AbstractFormDateSelect.php
@@ -224,12 +224,15 @@ abstract class AbstractFormDateSelect extends AbstractHelper
             return $this->selectHelper;
         }
 
-        if (method_exists($this->view, 'plugin')) {
+        if ($this->view && method_exists($this->view, 'plugin')) {
             $selectHelper = $this->view->plugin('formselect');
-            assert($selectHelper instanceof FormSelect);
             $this->selectHelper = $selectHelper;
         }
-        assert(null !== $this->selectHelper);
+
+        if (! $this->selectHelper instanceof FormSelect)
+        {
+            $this->selectHelper = new FormSelect();
+        }
 
         return $this->selectHelper;
     }

--- a/src/View/Helper/AbstractFormDateSelect.php
+++ b/src/View/Helper/AbstractFormDateSelect.php
@@ -9,7 +9,6 @@ use IntlDateFormatter;
 use Laminas\Form\Exception;
 use Locale;
 
-use function assert;
 use function extension_loaded;
 use function method_exists;
 use function preg_split;
@@ -225,12 +224,10 @@ abstract class AbstractFormDateSelect extends AbstractHelper
         }
 
         if ($this->view && method_exists($this->view, 'plugin')) {
-            $selectHelper = $this->view->plugin('formselect');
-            $this->selectHelper = $selectHelper;
+            $this->selectHelper = $this->view->plugin('formselect');
         }
 
-        if (! $this->selectHelper instanceof FormSelect)
-        {
+        if (! $this->selectHelper instanceof FormSelect) {
             $this->selectHelper = new FormSelect();
         }
 

--- a/src/View/Helper/FormMultiCheckbox.php
+++ b/src/View/Helper/FormMultiCheckbox.php
@@ -393,7 +393,7 @@ class FormMultiCheckbox extends FormInput
             return $this->inputHelper;
         }
 
-        if (method_exists($this->view, 'plugin')) {
+        if ($this->view && method_exists($this->view, 'plugin')) {
             $this->inputHelper = $this->view->plugin('form_input');
         }
 

--- a/src/View/Helper/FormMultiCheckbox.php
+++ b/src/View/Helper/FormMultiCheckbox.php
@@ -393,11 +393,11 @@ class FormMultiCheckbox extends FormInput
             return $this->inputHelper;
         }
 
-        if ($this->view && method_exists($this->view, 'plugin')) {
+        if (null !== $this->view && method_exists($this->view, 'plugin')) {
             $this->inputHelper = $this->view->plugin('form_input');
         }
 
-        if (! $this->inputHelper instanceof FormInput) {
+        if (null === $this->inputHelper) {
             $this->inputHelper = new FormInput();
         }
 

--- a/src/View/Helper/FormSelect.php
+++ b/src/View/Helper/FormSelect.php
@@ -298,7 +298,7 @@ class FormSelect extends AbstractHelper
     protected function getFormHiddenHelper(): FormHidden
     {
         if (! $this->formHiddenHelper) {
-            if (method_exists($this->view, 'plugin')) {
+            if ($this->view && method_exists($this->view, 'plugin')) {
                 $this->formHiddenHelper = $this->view->plugin('formhidden');
             }
 

--- a/src/View/Helper/FormSelect.php
+++ b/src/View/Helper/FormSelect.php
@@ -301,11 +301,11 @@ class FormSelect extends AbstractHelper
             return $this->formHiddenHelper;
         }
 
-        if ($this->view && method_exists($this->view, 'plugin')) {
+        if (null !== $this->view && method_exists($this->view, 'plugin')) {
             $this->formHiddenHelper = $this->view->plugin('formhidden');
         }
 
-        if (! $this->formHiddenHelper instanceof FormHidden) {
+        if (null === $this->formHiddenHelper) {
             $this->formHiddenHelper = new FormHidden();
         }
 

--- a/src/View/Helper/FormSelect.php
+++ b/src/View/Helper/FormSelect.php
@@ -297,14 +297,16 @@ class FormSelect extends AbstractHelper
 
     protected function getFormHiddenHelper(): FormHidden
     {
-        if (! $this->formHiddenHelper) {
-            if ($this->view && method_exists($this->view, 'plugin')) {
-                $this->formHiddenHelper = $this->view->plugin('formhidden');
-            }
+        if (null !== $this->formHiddenHelper) {
+            return $this->formHiddenHelper;
+        }
 
-            if (! $this->formHiddenHelper instanceof FormHidden) {
-                $this->formHiddenHelper = new FormHidden();
-            }
+        if ($this->view && method_exists($this->view, 'plugin')) {
+            $this->formHiddenHelper = $this->view->plugin('formhidden');
+        }
+
+        if (! $this->formHiddenHelper instanceof FormHidden) {
+            $this->formHiddenHelper = new FormHidden();
         }
 
         return $this->formHiddenHelper;

--- a/test/View/Helper/FormDateSelectTest.php
+++ b/test/View/Helper/FormDateSelectTest.php
@@ -44,6 +44,16 @@ final class FormDateSelectTest extends AbstractCommonTestCase
         self::assertStringContainsString('<select name="year"', $markup);
     }
 
+    public function testGeneratesWithoutRenderer(): void
+    {
+        $element = new DateSelect('foo');
+        $helper = new FormDateSelectHelper();
+        $markup  = $helper->render($element);
+        self::assertStringContainsString('<select name="day"', $markup);
+        self::assertStringContainsString('<select name="month"', $markup);
+        self::assertStringContainsString('<select name="year"', $markup);
+    }
+
     public function testCanGenerateSelectsWithEmptyOption(): void
     {
         $element = new DateSelect('foo');

--- a/test/View/Helper/FormDateSelectTest.php
+++ b/test/View/Helper/FormDateSelectTest.php
@@ -47,7 +47,7 @@ final class FormDateSelectTest extends AbstractCommonTestCase
     public function testGeneratesWithoutRenderer(): void
     {
         $element = new DateSelect('foo');
-        $helper = new FormDateSelectHelper();
+        $helper  = new FormDateSelectHelper();
         $markup  = $helper->render($element);
         self::assertStringContainsString('<select name="day"', $markup);
         self::assertStringContainsString('<select name="month"', $markup);

--- a/test/View/Helper/FormSelectTest.php
+++ b/test/View/Helper/FormSelectTest.php
@@ -8,7 +8,6 @@ use Laminas\Form\Element;
 use Laminas\Form\Element\Select as SelectElement;
 use Laminas\Form\Exception\DomainException;
 use Laminas\Form\Exception\InvalidArgumentException;
-use Laminas\Form\View\Helper\FormSelect;
 use Laminas\Form\View\Helper\FormSelect as FormSelectHelper;
 use Laminas\I18n\Translator\Translator;
 use LaminasTest\Form\TestAsset\Identifier;
@@ -401,7 +400,7 @@ final class FormSelectTest extends AbstractCommonTestCase
         $element = new SelectElement('foo');
         $element->setUseHiddenElement(true);
         $element->setUnselectedValue('empty');
-        $helper = new FormSelect();
+        $helper = new FormSelectHelper();
         $markup = $helper->render($element);
         self::assertStringContainsString('<input type="hidden" name="foo" value="empty"><select', $markup);
     }

--- a/test/View/Helper/FormSelectTest.php
+++ b/test/View/Helper/FormSelectTest.php
@@ -8,6 +8,7 @@ use Laminas\Form\Element;
 use Laminas\Form\Element\Select as SelectElement;
 use Laminas\Form\Exception\DomainException;
 use Laminas\Form\Exception\InvalidArgumentException;
+use Laminas\Form\View\Helper\FormSelect;
 use Laminas\Form\View\Helper\FormSelect as FormSelectHelper;
 use Laminas\I18n\Translator\Translator;
 use LaminasTest\Form\TestAsset\Identifier;
@@ -392,6 +393,16 @@ final class FormSelectTest extends AbstractCommonTestCase
         $element->setUnselectedValue('empty');
 
         $markup = $this->helper->render($element);
+        self::assertStringContainsString('<input type="hidden" name="foo" value="empty"><select', $markup);
+    }
+
+    public function testHiddenElementWhenNoRenderer(): void
+    {
+        $element = new SelectElement('foo');
+        $element->setUseHiddenElement(true);
+        $element->setUnselectedValue('empty');
+        $helper = new FormSelect();
+        $markup = $helper->render($element);
         self::assertStringContainsString('<input type="hidden" name="foo" value="empty"><select', $markup);
     }
 


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Inconsistencies in the way different view helpers load plugins meant that while most helpers worked without a renderer being attached on $this->view, a few failed.

This PR brings the few cases where plugins weren't successfully created when $this->view wasn't populated into line with the others and includes unit tests that fail before the change.

- Are you fixing a BC Break?

Arguably?
In some older versions of PHP (ie 7.4) some of these cases (eg FormSelect::getFormHiddenHelper()) would work (because $this->view being null only became a TypeError for method_exists() in PHP 8.0) and then stopped working on current PHP versions.
So these fixes would make code that worked for people under older versions of PHP continue to work as they uplift their PHP and Laminas versions.

There is a little background on:
https://discourse.laminas.dev/t/laminas-form-view-helper-retrieval-consistency/3591