### PR TITLE
Added novalidate to boolean attributes array

### DIFF
--- a/src/View/Helper/AbstractHelper.php
+++ b/src/View/Helper/AbstractHelper.php
@@ -51,14 +51,14 @@ abstract class AbstractHelper extends BaseAbstractHelper
      * @var array
      */
     protected $booleanAttributes = [
-        'autofocus' => ['on' => 'autofocus', 'off' => ''], // https://html.spec.whatwg.org/#attr-fe-autofocus
-        'checked'   => ['on' => 'checked',   'off' => ''], // https://html.spec.whatwg.org/#attr-input-checked
-        'disabled'  => ['on' => 'disabled',  'off' => ''], // https://html.spec.whatwg.org/#attr-fe-disabled
-        'itemscope' => ['on' => 'itemscope', 'off' => ''], // https://html.spec.whatwg.org/#attr-itemscope
-        'multiple'  => ['on' => 'multiple',  'off' => ''], // https://html.spec.whatwg.org/#attr-input-multiple
-        'readonly'  => ['on' => 'readonly',  'off' => ''], // https://html.spec.whatwg.org/#attr-input-readonly
-        'required'  => ['on' => 'required',  'off' => ''], // https://html.spec.whatwg.org/#attr-input-required
-        'selected'  => ['on' => 'selected',  'off' => ''], // https://html.spec.whatwg.org/#attr-option-selected
+        'autofocus'  => ['on' => 'autofocus', 'off' => ''], // https://html.spec.whatwg.org/#attr-fe-autofocus
+        'checked'    => ['on' => 'checked',   'off' => ''], // https://html.spec.whatwg.org/#attr-input-checked
+        'disabled'   => ['on' => 'disabled',  'off' => ''], // https://html.spec.whatwg.org/#attr-fe-disabled
+        'itemscope'  => ['on' => 'itemscope', 'off' => ''], // https://html.spec.whatwg.org/#attr-itemscope
+        'multiple'   => ['on' => 'multiple',  'off' => ''], // https://html.spec.whatwg.org/#attr-input-multiple
+        'readonly'   => ['on' => 'readonly',  'off' => ''], // https://html.spec.whatwg.org/#attr-input-readonly
+        'required'   => ['on' => 'required',  'off' => ''], // https://html.spec.whatwg.org/#attr-input-required
+        'selected'   => ['on' => 'selected',  'off' => ''], // https://html.spec.whatwg.org/#attr-option-selected
         'novalidate' => ['on' => 'novalidate', 'off' => ''], // https://html.spec.whatwg.org/#attr-option-selected
     ];
 

--- a/src/View/Helper/AbstractHelper.php
+++ b/src/View/Helper/AbstractHelper.php
@@ -59,7 +59,7 @@ abstract class AbstractHelper extends BaseAbstractHelper
         'readonly'   => ['on' => 'readonly',  'off' => ''], // https://html.spec.whatwg.org/#attr-input-readonly
         'required'   => ['on' => 'required',  'off' => ''], // https://html.spec.whatwg.org/#attr-input-required
         'selected'   => ['on' => 'selected',  'off' => ''], // https://html.spec.whatwg.org/#attr-option-selected
-        'novalidate' => ['on' => 'novalidate', 'off' => ''], // https://html.spec.whatwg.org/#attr-option-selected
+        'novalidate' => ['on' => 'novalidate', 'off' => ''], // https://html.spec.whatwg.org/#attr-fs-novalidate
     ];
 
     /**

--- a/src/View/Helper/AbstractHelper.php
+++ b/src/View/Helper/AbstractHelper.php
@@ -51,14 +51,14 @@ abstract class AbstractHelper extends BaseAbstractHelper
      * @var array
      */
     protected $booleanAttributes = [
-        'autofocus' =>  ['on' => 'autofocus',  'off' => ''], // https://html.spec.whatwg.org/#attr-fe-autofocus
-        'checked'   =>  ['on' => 'checked',    'off' => ''], // https://html.spec.whatwg.org/#attr-input-checked
-        'disabled'  =>  ['on' => 'disabled',   'off' => ''], // https://html.spec.whatwg.org/#attr-fe-disabled
-        'itemscope' =>  ['on' => 'itemscope',  'off' => ''], // https://html.spec.whatwg.org/#attr-itemscope
-        'multiple'  =>  ['on' => 'multiple',   'off' => ''], // https://html.spec.whatwg.org/#attr-input-multiple
-        'readonly'  =>  ['on' => 'readonly',   'off' => ''], // https://html.spec.whatwg.org/#attr-input-readonly
-        'required'  =>  ['on' => 'required',   'off' => ''], // https://html.spec.whatwg.org/#attr-input-required
-        'selected'  =>  ['on' => 'selected',   'off' => ''], // https://html.spec.whatwg.org/#attr-option-selected
+        'autofocus' => ['on' => 'autofocus', 'off' => ''], // https://html.spec.whatwg.org/#attr-fe-autofocus
+        'checked'   => ['on' => 'checked',   'off' => ''], // https://html.spec.whatwg.org/#attr-input-checked
+        'disabled'  => ['on' => 'disabled',  'off' => ''], // https://html.spec.whatwg.org/#attr-fe-disabled
+        'itemscope' => ['on' => 'itemscope', 'off' => ''], // https://html.spec.whatwg.org/#attr-itemscope
+        'multiple'  => ['on' => 'multiple',  'off' => ''], // https://html.spec.whatwg.org/#attr-input-multiple
+        'readonly'  => ['on' => 'readonly',  'off' => ''], // https://html.spec.whatwg.org/#attr-input-readonly
+        'required'  => ['on' => 'required',  'off' => ''], // https://html.spec.whatwg.org/#attr-input-required
+        'selected'  => ['on' => 'selected',  'off' => ''], // https://html.spec.whatwg.org/#attr-option-selected
         'novalidate' => ['on' => 'novalidate', 'off' => ''], // https://html.spec.whatwg.org/#attr-option-selected
     ];
 

--- a/src/View/Helper/AbstractHelper.php
+++ b/src/View/Helper/AbstractHelper.php
@@ -51,14 +51,15 @@ abstract class AbstractHelper extends BaseAbstractHelper
      * @var array
      */
     protected $booleanAttributes = [
-        'autofocus' => ['on' => 'autofocus', 'off' => ''], // https://html.spec.whatwg.org/#attr-fe-autofocus
-        'checked'   => ['on' => 'checked',   'off' => ''], // https://html.spec.whatwg.org/#attr-input-checked
-        'disabled'  => ['on' => 'disabled',  'off' => ''], // https://html.spec.whatwg.org/#attr-fe-disabled
-        'itemscope' => ['on' => 'itemscope', 'off' => ''], // https://html.spec.whatwg.org/#attr-itemscope
-        'multiple'  => ['on' => 'multiple',  'off' => ''], // https://html.spec.whatwg.org/#attr-input-multiple
-        'readonly'  => ['on' => 'readonly',  'off' => ''], // https://html.spec.whatwg.org/#attr-input-readonly
-        'required'  => ['on' => 'required',  'off' => ''], // https://html.spec.whatwg.org/#attr-input-required
-        'selected'  => ['on' => 'selected',  'off' => ''], // https://html.spec.whatwg.org/#attr-option-selected
+        'autofocus' =>  ['on' => 'autofocus',  'off' => ''], // https://html.spec.whatwg.org/#attr-fe-autofocus
+        'checked'   =>  ['on' => 'checked',    'off' => ''], // https://html.spec.whatwg.org/#attr-input-checked
+        'disabled'  =>  ['on' => 'disabled',   'off' => ''], // https://html.spec.whatwg.org/#attr-fe-disabled
+        'itemscope' =>  ['on' => 'itemscope',  'off' => ''], // https://html.spec.whatwg.org/#attr-itemscope
+        'multiple'  =>  ['on' => 'multiple',   'off' => ''], // https://html.spec.whatwg.org/#attr-input-multiple
+        'readonly'  =>  ['on' => 'readonly',   'off' => ''], // https://html.spec.whatwg.org/#attr-input-readonly
+        'required'  =>  ['on' => 'required',   'off' => ''], // https://html.spec.whatwg.org/#attr-input-required
+        'selected'  =>  ['on' => 'selected',   'off' => ''], // https://html.spec.whatwg.org/#attr-option-selected
+        'novalidate' => ['on' => 'novalidate', 'off' => ''], // https://html.spec.whatwg.org/#attr-option-selected
     ];
 
     /**


### PR DESCRIPTION
I have added novalidate to the `AbstractHelper::$booleanAttributes` array as this is a boolean attribute in HTML 5.
Currently setting the `Element::setAttribute('novalidate', true)` in the form when the doc-type is set to HTML5, renders novalidate="1" rather than just novalidate.
https://html.spec.whatwg.org/#attr-fs-novalidate
