### PR TITLE
Loosen `checkForExclude` callback parameter type declaration

### DIFF
--- a/src/Annotation/AbstractBuilder.php
+++ b/src/Annotation/AbstractBuilder.php
@@ -310,7 +310,7 @@ abstract class AbstractBuilder implements EventManagerAwareInterface, FormFactor
 
         // @codingStandardsIgnoreStart
         $results = $this->getEventManager()->triggerEventUntil(
-            static fn(bool $r): bool => true === $r,
+            static fn(?bool $r): bool => true === $r,
             $event
         );
         // @codingStandardsIgnoreEnd

--- a/test/Annotation/AbstractBuilderTestCase.php
+++ b/test/Annotation/AbstractBuilderTestCase.php
@@ -30,6 +30,7 @@ use LaminasTest\Form\TestAsset\Annotation\EntityObjectPropertyHydrator;
 use LaminasTest\Form\TestAsset\Annotation\Form;
 use LaminasTest\Form\TestAsset\Annotation\InputFilter;
 use LaminasTest\Form\TestAsset\Annotation\InputFilterInput;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use PHPUnit\Framework\TestCase;
 use Throwable;
@@ -572,5 +573,18 @@ abstract class AbstractBuilderTestCase extends TestCase
         } finally {
             ErrorHandler::restoreErrorHandler();
         }
+    }
+
+    #[DoesNotPerformAssertions]
+    public function testAllowsEventListenerReturnVoid(): void
+    {
+        $entity  = new TestAsset\Annotation\Entity();
+        $builder = $this->createBuilder();
+
+        $builder->getEventManager()->attach('*', function () {
+            // return void;
+        });
+
+        $builder->createForm($entity);
     }
 }


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Assuming the current release is 1.5.0, the next patch release is 1.5.1, the next minor is 1.6.0 and the next major is 2.0.0, The Current release branch will be `1.5.x`, the next minor branch will be `1.6.x`, and the next major branch will be `2.0.x`

Pick the target branch based on the following criteria:
  * Documentation improvement: Current release branch 1.5.x
  * Bugfix: Current release branch 1.5.x
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: Next minor 1.6.x
  * New feature, or refactor of existing code: Next minor 1.6.x
  * Backwards incompatible features and refactoring: Next major 2.0.x

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Bugfix        | yes

### Description

Loosens the type declaration from `bool` -> `?bool` in `checkForExclude` callback. 

**Reproduction**:
Attach an event that returns `void` that listens for the `checkForExclude` (or `*`) event. 

Using `laminas-developer-tools` with the default setup (listening for all events) will have a listener that returns `void` (`\Laminas\DeveloperTools\Listener\EventLoggingListenerAggregate::onCollectEvent`). The `void` is passed as a parameter to the callback (as `null`) and causes a `TypeError`.

**Expected**:
To execute with listeners that return `void`.

**Actual**:
```
TypeError: Laminas\Form\Annotation\AbstractBuilder::Laminas\Form\Annotation\{closure}(): Argument #1 ($r) must be of type bool, null given, called in `vendor/laminas/laminas-eventmanager/src/EventManager.php` on line 330 `src/Annotation/AbstractBuilder.php:313`
```