### PR TITLE
Add failing test case for factory creation of elements with required options

### DIFF
--- a/test/FactoryTest.php
+++ b/test/FactoryTest.php
@@ -23,6 +23,7 @@ use Laminas\Validator\Digits;
 use Laminas\Validator\ValidatorChain;
 use Laminas\Validator\ValidatorInterface;
 use Laminas\Validator\ValidatorPluginManager;
+use LaminasTest\Form\TestAsset\CustomElementWithRequiredOption;
 use LaminasTest\Form\TestAsset\InputFilter;
 use LaminasTest\Form\TestAsset\Model;
 use PHPUnit\Framework\TestCase;
@@ -848,5 +849,71 @@ final class FactoryTest extends TestCase
 
         self::assertInstanceOf(TestAsset\FieldsetWithDependency::class, $targetElement);
         self::assertInstanceOf(InputFilter::class, $targetElement->getDependency());
+    }
+
+    public function testElementWithRequiredOptionsNestedInFieldsetOrCollection(): void
+    {
+        $formManager = $this->factory->getFormElementManager();
+        $formManager->setFactory(
+            TestAsset\FieldsetWithDependency::class,
+            TestAsset\FieldsetWithDependencyFactory::class
+        );
+
+        $collection = $this->factory->create([
+            'type'    => Form\Element\Collection::class,
+            'name'    => 'my_fieldset_collection',
+            'options' => [
+                'target_element' => [
+                    'type'    => CustomElementWithRequiredOption::class,
+                    'options' => [
+                        'requiredOption' => 'Any String',
+                    ],
+                ],
+            ],
+        ]);
+        self::assertInstanceOf(Form\Element\Collection::class, $collection);
+        $element = $collection->getTargetElement();
+        self::assertInstanceOf(CustomElementWithRequiredOption::class, $element);
+        self::assertSame('Any String', $element->myString);
+    }
+
+    public function testCreateElementWithRequiredOption(): void
+    {
+        $element = $this->factory->create([
+            'type'    => CustomElementWithRequiredOption::class,
+            'name'    => 'foo',
+            'options' => [
+                'requiredOption' => 'Any String',
+            ],
+        ]);
+
+        self::assertInstanceOf(CustomElementWithRequiredOption::class, $element);
+        self::assertSame('Any String', $element->myString);
+    }
+
+    public function testCanCreateElementWithConstructorDependency(): void
+    {
+        $formManager = $this->factory->getFormElementManager();
+        $formManager->setFactory(
+            TestAsset\CustomElementWithConstructorDependency::class,
+            TestAsset\CustomElementWithConstructorDependencyFactory::class
+        );
+
+        $collection = $this->factory->create([
+            'type'    => Form\Element\Collection::class,
+            'name'    => 'my_fieldset_collection',
+            'options' => [
+                'target_element' => [
+                    'type' => TestAsset\CustomElementWithConstructorDependency::class,
+                ],
+            ],
+        ]);
+
+        self::assertInstanceOf(Form\Element\Collection::class, $collection);
+
+        $targetElement = $collection->getTargetElement();
+
+        self::assertInstanceOf(TestAsset\CustomElementWithConstructorDependency::class, $targetElement);
+        self::assertSame('FOO', $targetElement->myString);
     }
 }

--- a/test/TestAsset/CustomElementWithConstructorDependency.php
+++ b/test/TestAsset/CustomElementWithConstructorDependency.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Form\TestAsset;
+
+use Laminas\Form\Element\MultiCheckbox;
+
+final class CustomElementWithConstructorDependency extends MultiCheckbox
+{
+    public function __construct(
+        string|null $name = null,
+        iterable $options = [],
+        public readonly string $myString, // phpcs:ignore
+    ) {
+        parent::__construct($name, $options);
+    }
+}

--- a/test/TestAsset/CustomElementWithConstructorDependencyFactory.php
+++ b/test/TestAsset/CustomElementWithConstructorDependencyFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Form\TestAsset;
+
+use Psr\Container\ContainerInterface;
+
+final class CustomElementWithConstructorDependencyFactory
+{
+    public function __invoke(
+        ContainerInterface $container,
+        string $requestedName,
+        array|null $options = null,
+    ): CustomElementWithConstructorDependency {
+        return new CustomElementWithConstructorDependency(
+            null,
+            $options ?? [],
+            'FOO',
+        );
+    }
+}

--- a/test/TestAsset/CustomElementWithRequiredOption.php
+++ b/test/TestAsset/CustomElementWithRequiredOption.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Form\TestAsset;
+
+use Laminas\Form\Element\MultiCheckbox;
+
+final class CustomElementWithRequiredOption extends MultiCheckbox
+{
+    public readonly string $myString;
+
+    /** @param array<array-key, mixed> $options */
+    public function __construct(string|null $name = null, iterable $options = [])
+    {
+        /**
+         * The null assignment causes a type error which is desired
+         *
+         * @psalm-suppress PossiblyNullPropertyAssignmentValue
+         */
+        $this->myString = $options['requiredOption'] ?? null;
+
+        parent::__construct($name, $options);
+    }
+}


### PR DESCRIPTION
It is not possible to use custom elements with required options via configuration, i.e.

```php
$this->add([
  'name' => 'foo',
  'type' => Whatever::class,
  'options' => ['some' => 'thing'],
]);
```

This can be fixed in [Factory](https://github.com/laminas/laminas-form/blob/3.22.x/src/Factory.php#L110) by passing any options found in `$spec` but this reveals more problematic issues with collections, for example. Because the options are given to the Collection at construction time, it creates the nested element(s) before the factory has been injected (via setter injection in the plugin manager initialisers) - This causes a fresh plugin manager to be created inside the collection with a call to `->get('NestedElement')` for an unknown element (By default the plugin manager will auto add an invokable factory).
