### PR TITLE
Undeprecate AllowEmpty and ContinueIfEmpty attributes

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1188,21 +1188,10 @@
         ])]]></code>
     </DeprecatedClass>
   </file>
-  <file src="test/TestAsset/Annotation/ComplexEntity.php">
-    <DeprecatedClass>
-      <code><![CDATA[Annotation\AllowEmpty()]]></code>
-    </DeprecatedClass>
-  </file>
   <file src="test/TestAsset/Annotation/LegacyHydratorAnnotation.php">
     <MissingPropertyType>
       <code><![CDATA[$username]]></code>
     </MissingPropertyType>
-  </file>
-  <file src="test/TestAsset/Annotation/SampleEntity.php">
-    <DeprecatedClass>
-      <code><![CDATA[Annotation\AllowEmpty(true)]]></code>
-      <code><![CDATA[Annotation\ContinueIfEmpty(true)]]></code>
-    </DeprecatedClass>
   </file>
   <file src="test/TestAsset/CreateAddressForm.php">
     <UndefinedInterfaceMethod>

--- a/src/Annotation/AllowEmpty.php
+++ b/src/Annotation/AllowEmpty.php
@@ -17,8 +17,6 @@ use function is_bool;
  * Presence of this annotation is a hint that the associated
  * \Laminas\InputFilter\Input should enable the allowEmpty flag.
  *
- * @deprecated 2.4.8 Use `@Validator({"name":"NotEmpty"})` instead.
- *
  * @Annotation
  * @NamedArgumentConstructor
  */

--- a/src/Annotation/ContinueIfEmpty.php
+++ b/src/Annotation/ContinueIfEmpty.php
@@ -17,8 +17,6 @@ use function is_bool;
  * Presence of this annotation is a hint that the associated
  * \Laminas\InputFilter\Input should enable the continueIfEmpty flag.
  *
- * @deprecated 2.4.8 Use `@Validator({"name":"NotEmpty"})` instead.
- *
  * @Annotation
  * @NamedArgumentConstructor
  */


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes (kinda: PHPDocs)
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

These were undeprecated [in laminas-inputfilter](https://github.com/laminas/laminas-inputfilter/pull/77) and [in the docs](https://github.com/laminas/laminas-form/pull/214) as there is no alternative available or planned. This PR removes the `@deprecated` tag from the attributes to avoid confusion for users of laminas-form.