### PR TITLE
Fix error validating form with nested custom fieldset

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -14,7 +14,6 @@ use Laminas\InputFilter\InputFilterProviderInterface;
 use Laminas\InputFilter\InputProviderInterface;
 use Laminas\InputFilter\ReplaceableInputInterface;
 use Laminas\Stdlib\ArrayUtils;
-use Laminas\Stdlib\PriorityList;
 use Traversable;
 
 use function array_key_exists;
@@ -23,6 +22,7 @@ use function assert;
 use function in_array;
 use function is_array;
 use function is_object;
+use function iterator_to_array;
 use function sprintf;
 
 /**
@@ -549,14 +549,12 @@ class Form extends Fieldset implements FormInterface
         array $data,
         array &$validationGroup
     ): void {
+        $elements = iterator_to_array($formOrFieldset->getIterator());
         foreach ($validationGroup as $key => &$value) {
-            $iterator = $formOrFieldset->getIterator();
-            assert($iterator instanceof PriorityList);
-            $fieldset = $iterator->get((string) $key);
-
-            if (! $fieldset) {
+            if (! isset($elements[$key])) {
                 continue;
             }
+            $fieldset = $elements[$key];
 
             if ($fieldset instanceof CollectionInterface) {
                 if (! isset($data[$key]) && $fieldset->getCount() === 0) {

--- a/src/Form.php
+++ b/src/Form.php
@@ -14,6 +14,7 @@ use Laminas\InputFilter\InputFilterProviderInterface;
 use Laminas\InputFilter\InputProviderInterface;
 use Laminas\InputFilter\ReplaceableInputInterface;
 use Laminas\Stdlib\ArrayUtils;
+use Laminas\Stdlib\PriorityList;
 use Traversable;
 
 use function array_key_exists;
@@ -534,10 +535,15 @@ class Form extends Fieldset implements FormInterface
      * Prepare the validation group in case Collection elements were used (this function also handle
      * the case where elements could have been dynamically added or removed from a collection using JavaScript)
      */
-    protected function prepareValidationGroup(Fieldset $formOrFieldset, array $data, array &$validationGroup): void
-    {
+    protected function prepareValidationGroup(
+        FieldsetInterface $formOrFieldset,
+        array $data,
+        array &$validationGroup
+    ): void {
         foreach ($validationGroup as $key => &$value) {
-            $fieldset = $formOrFieldset->iterator->get((string) $key);
+            $iterator = $formOrFieldset->getIterator();
+            assert($iterator instanceof PriorityList);
+            $fieldset = $iterator->get((string) $key);
 
             if (! $fieldset) {
                 continue;

--- a/src/Form.php
+++ b/src/Form.php
@@ -535,7 +535,16 @@ class Form extends Fieldset implements FormInterface
      * Prepare the validation group in case Collection elements were used (this function also handle
      * the case where elements could have been dynamically added or removed from a collection using JavaScript)
      */
-    protected function prepareValidationGroup(
+    protected function prepareValidationGroup(Fieldset $formOrFieldset, array $data, array &$validationGroup): void
+    {
+        $this->prepareFieldsetValidationGroup($formOrFieldset, $data, $validationGroup);
+    }
+
+    /**
+     * @fixme This is here to preserve BC on `prepareValidationGroup` and can be removed on next major if that method's
+     *        signature is changed to accept a `FieldsetInterface`
+     */
+    private function prepareFieldsetValidationGroup(
         FieldsetInterface $formOrFieldset,
         array $data,
         array &$validationGroup
@@ -569,7 +578,7 @@ class Form extends Fieldset implements FormInterface
             if (! isset($data[$key])) {
                 $data[$key] = [];
             }
-            $this->prepareValidationGroup($fieldset, $data[$key], $validationGroup[$key]);
+            $this->prepareFieldsetValidationGroup($fieldset, $data[$key], $validationGroup[$key]);
         }
     }
 

--- a/test/FormTest.php
+++ b/test/FormTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace LaminasTest\Form;
 
-use ArrayIterator;
 use ArrayObject;
 use Laminas\Form\Element;
 use Laminas\Form\Element\CollectionInterface;

--- a/test/FormTest.php
+++ b/test/FormTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace LaminasTest\Form;
 
+use ArrayIterator;
 use ArrayObject;
 use Laminas\Form\Element;
 use Laminas\Form\Element\CollectionInterface;
@@ -25,6 +26,7 @@ use Laminas\InputFilter\Input;
 use Laminas\InputFilter\InputFilter;
 use Laminas\InputFilter\InputFilterInterface;
 use Laminas\InputFilter\InputInterface;
+use Laminas\Stdlib\PriorityList;
 use LaminasTest\Form\TestAsset\Entity\Category;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
@@ -605,6 +607,54 @@ final class FormTest extends TestCase
         self::assertInstanceOf(Category::class, $model->categories[0]);
         self::assertEquals('category', $model->categories[0]->getName());
         self::assertFalse(isset($model->foobar));
+    }
+
+    public function testFormWithNestedCustomCollectionAndValidationGroupBindValuesToModel(): void
+    {
+        $model = new stdClass();
+        $data  = [
+            'foo'       => 'abcde',
+            'top_level' => [
+                'categories' => [
+                    [
+                        'name' => 'category',
+                    ],
+                ],
+            ],
+        ];
+        $this->populateForm();
+
+        $collection = self::createStub(CollectionInterface::class);
+        $collection->method('getName')
+            ->willReturn('categories');
+        $collection->method('getIterator')
+            ->willReturn(new PriorityList());
+        $collection->method('getTargetElement')
+            ->willReturn(new TestAsset\CategoryFieldset());
+
+        $fieldset = new Fieldset('top_level');
+        $fieldset->add($collection);
+
+        $this->form->add($fieldset);
+        $this->form->setHydrator(new ObjectPropertyHydrator());
+        $this->form->bind($model);
+        $this->form->setData($data);
+        $this->form->setValidationGroup([
+            'foo',
+            'top_level' => [
+                'categories' => [
+                    'name',
+                ],
+            ],
+        ]);
+        $this->form->isValid();
+
+        self::assertTrue(isset($model->top_level));
+        self::assertIsArray($model->top_level);
+        self::assertTrue(isset($model->top_level['categories']));
+        self::assertIsArray($model->top_level['categories']);
+        self::assertIsArray($model->top_level['categories'][0]);
+        self::assertEquals('category', $model->top_level['categories'][0]['name']);
     }
 
     public function testSettingValidationGroupWithoutCollectionBindsOnlyThoseValuesToModel(): void


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

If you add a nested fieldset (implementing `FieldsetInterface`) to a form, validation fails with:
```
1) LaminasTest\Form\FormTest::testFormWithNestedCustomCollectionAndValidationGroupBindValuesToModel
TypeError: Laminas\Form\Form::prepareValidationGroup(): Argument #1 ($formOrFieldset) must be of type Laminas\Form\Fieldset, MockObject_CollectionInterface_7c6d4c8a given, called in /Users/matt/www/laminas-form/src/Form.php on line 566
```

This change allows nested `FieldsetsetInterfaces` to be validated.
