### PR TITLE
Fix injecting form Factory into custom fieldsets

### DIFF
--- a/src/FormElementManager.php
+++ b/src/FormElementManager.php
@@ -18,6 +18,7 @@ use function array_search;
 use function array_unshift;
 use function class_exists;
 use function get_debug_type;
+use function method_exists;
 use function sprintf;
 
 /**
@@ -213,7 +214,11 @@ class FormElementManager extends AbstractPluginManager
      */
     public function injectFactory(ContainerInterface $container, mixed $instance): void
     {
-        if (! $instance instanceof Fieldset) {
+        if (! $instance instanceof FieldsetInterface) {
+            return;
+        }
+
+        if (! method_exists($instance, 'getFormFactory')) {
             return;
         }
 

--- a/test/FormElementManagerTest.php
+++ b/test/FormElementManagerTest.php
@@ -9,6 +9,7 @@ use Laminas\Form\ElementFactory;
 use Laminas\Form\Exception\DomainException;
 use Laminas\Form\Exception\InvalidElementException;
 use Laminas\Form\Factory;
+use Laminas\Form\FieldsetInterface;
 use Laminas\Form\Form;
 use Laminas\Form\FormElementManager;
 use Laminas\Hydrator\HydratorInterface;
@@ -16,6 +17,7 @@ use Laminas\Hydrator\HydratorPluginManager;
 use Laminas\ServiceManager\Exception\InvalidServiceException;
 use Laminas\ServiceManager\PluginManagerInterface;
 use Laminas\ServiceManager\ServiceManager;
+use LaminasTest\Form\TestAsset\FieldsetInterfaceImplementation;
 use LaminasTest\Form\TestAsset\InvokableForm;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -60,6 +62,20 @@ final class FormElementManagerTest extends TestCase
         assert($form instanceof Form);
         self::assertSame($factory, $form->getFormFactory());
         self::assertSame($this->manager, $form->getFormFactory()->getFormElementManager());
+    }
+
+    public function testInjectFormElementManagerToCustomFieldset(): void
+    {
+        $factory = new Factory();
+        $this->manager->setFactory('my-fieldset', static function ($elements) use ($factory): FieldsetInterface {
+            $fieldset = new FieldsetInterfaceImplementation();
+            $fieldset->setFormFactory($factory);
+            return $fieldset;
+        });
+        $fieldset = $this->manager->get('my-fieldset');
+        assert($fieldset instanceof FieldsetInterfaceImplementation);
+        self::assertSame($factory, $fieldset->getFormFactory());
+        self::assertSame($this->manager, $fieldset->getFormFactory()->getFormElementManager());
     }
 
     public function testRegisteringInvalidElementRaisesException(): void

--- a/test/TestAsset/FieldsetInterfaceImplementation.php
+++ b/test/TestAsset/FieldsetInterfaceImplementation.php
@@ -1,0 +1,213 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Form\TestAsset;
+
+use Laminas\Form\Element;
+use Laminas\Form\ElementInterface;
+use Laminas\Form\Factory;
+use Laminas\Form\FieldsetInterface;
+use Laminas\Form\FormInterface;
+use Laminas\Hydrator\HydratorInterface;
+use Traversable;
+
+final class FieldsetInterfaceImplementation implements FieldsetInterface
+{
+    private Factory $formFactory;
+
+    public function __construct()
+    {
+        $this->formFactory = new Factory();
+    }
+
+    public function getIterator(): Traversable
+    {
+        return new \ArrayIterator([]);
+    }
+
+    public function count(): int
+    {
+        return 0;
+    }
+
+    public function setName(string $name)
+    {
+        return $this;
+    }
+
+    public function getName(): ?string
+    {
+        return null;
+    }
+
+    public function setOptions(iterable $options)
+    {
+        return $this;
+    }
+
+    public function setOption(string $key, mixed $value)
+    {
+        return $this;
+    }
+
+    public function getOptions(): array
+    {
+        return [];
+    }
+
+    public function getOption(string $option)
+    {
+        return null;
+    }
+
+    public function setAttribute(string $key, mixed $value)
+    {
+        return $this;
+    }
+
+    public function getAttribute(string $key)
+    {
+        return null;
+    }
+
+    public function hasAttribute(string $key): bool
+    {
+        return false;
+    }
+
+    public function setAttributes(iterable $arrayOrTraversable)
+    {
+        return $this;
+    }
+
+    public function getAttributes(): array
+    {
+        return [];
+    }
+
+    public function setValue(mixed $value)
+    {
+        return $this;
+    }
+
+    public function getValue()
+    {
+        return null;
+    }
+
+    public function setLabel(?string $label)
+    {
+        return $this;
+    }
+
+    public function getLabel(): ?string
+    {
+        return null;
+    }
+
+    public function setMessages(iterable $messages)
+    {
+        return $this;
+    }
+
+    public function getMessages(): array
+    {
+        return [];
+    }
+
+    public function prepareElement(FormInterface $form): void
+    {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function add($elementOrFieldset, array $flags = [])
+    {
+        return $this;
+    }
+
+    public function has(string $elementOrFieldset): bool
+    {
+        return false;
+    }
+
+    public function get(string $elementOrFieldset): ElementInterface
+    {
+        return new Element();
+    }
+
+    public function remove(string $elementOrFieldset)
+    {
+        return $this;
+    }
+
+    public function setPriority(string $elementOrFieldset, int $priority)
+    {
+        return $this;
+    }
+
+    public function getElements(): array
+    {
+        return [];
+    }
+
+    public function getFieldsets(): array
+    {
+        return [];
+    }
+
+    public function populateValues(iterable $data): void
+    {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setObject($object)
+    {
+        return $this;
+    }
+
+    public function getObject()
+    {
+        return null;
+    }
+
+    public function allowObjectBinding(object $object): bool
+    {
+        return false;
+    }
+
+    public function setHydrator(HydratorInterface $hydrator)
+    {
+        return $this;
+    }
+
+    public function getHydrator(): ?HydratorInterface
+    {
+        return null;
+    }
+
+    public function bindValues(array $values = [])
+    {
+        return null;
+    }
+
+    public function allowValueBinding(): bool
+    {
+        return false;
+    }
+
+    public function setFormFactory(Factory $formFactory)
+    {
+        $this->formFactory = $formFactory;
+        return $this;
+    }
+
+    public function getFormFactory(): Factory
+    {
+        return $this->formFactory;
+    }
+}

--- a/test/TestAsset/FieldsetInterfaceImplementation.php
+++ b/test/TestAsset/FieldsetInterfaceImplementation.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace LaminasTest\Form\TestAsset;
 
+use ArrayIterator;
 use Laminas\Form\Element;
 use Laminas\Form\ElementInterface;
 use Laminas\Form\Factory;
@@ -23,7 +24,7 @@ final class FieldsetInterfaceImplementation implements FieldsetInterface
 
     public function getIterator(): Traversable
     {
-        return new \ArrayIterator([]);
+        return new ArrayIterator([]);
     }
 
     public function count(): int
@@ -31,6 +32,9 @@ final class FieldsetInterfaceImplementation implements FieldsetInterface
         return 0;
     }
 
+    /**
+     * @inheritDoc
+     */
     public function setName(string $name)
     {
         return $this;
@@ -41,11 +45,17 @@ final class FieldsetInterfaceImplementation implements FieldsetInterface
         return null;
     }
 
+    /**
+     * @inheritDoc
+     */
     public function setOptions(iterable $options)
     {
         return $this;
     }
 
+    /**
+     * @inheritDoc
+     */
     public function setOption(string $key, mixed $value)
     {
         return $this;
@@ -56,16 +66,25 @@ final class FieldsetInterfaceImplementation implements FieldsetInterface
         return [];
     }
 
+    /**
+     * @inheritDoc
+     */
     public function getOption(string $option)
     {
         return null;
     }
 
+    /**
+     * @inheritDoc
+     */
     public function setAttribute(string $key, mixed $value)
     {
         return $this;
     }
 
+    /**
+     * @inheritDoc
+     */
     public function getAttribute(string $key)
     {
         return null;
@@ -76,6 +95,9 @@ final class FieldsetInterfaceImplementation implements FieldsetInterface
         return false;
     }
 
+    /**
+     * @inheritDoc
+     */
     public function setAttributes(iterable $arrayOrTraversable)
     {
         return $this;
@@ -86,16 +108,25 @@ final class FieldsetInterfaceImplementation implements FieldsetInterface
         return [];
     }
 
+    /**
+     * @inheritDoc
+     */
     public function setValue(mixed $value)
     {
         return $this;
     }
 
+    /**
+     * @inheritDoc
+     */
     public function getValue()
     {
         return null;
     }
 
+    /**
+     * @inheritDoc
+     */
     public function setLabel(?string $label)
     {
         return $this;
@@ -106,6 +137,9 @@ final class FieldsetInterfaceImplementation implements FieldsetInterface
         return null;
     }
 
+    /**
+     * @inheritDoc
+     */
     public function setMessages(iterable $messages)
     {
         return $this;
@@ -138,11 +172,17 @@ final class FieldsetInterfaceImplementation implements FieldsetInterface
         return new Element();
     }
 
+    /**
+     * @inheritDoc
+     */
     public function remove(string $elementOrFieldset)
     {
         return $this;
     }
 
+    /**
+     * @inheritDoc
+     */
     public function setPriority(string $elementOrFieldset, int $priority)
     {
         return $this;
@@ -170,6 +210,9 @@ final class FieldsetInterfaceImplementation implements FieldsetInterface
         return $this;
     }
 
+    /**
+     * @inheritDoc
+     */
     public function getObject()
     {
         return null;
@@ -180,6 +223,9 @@ final class FieldsetInterfaceImplementation implements FieldsetInterface
         return false;
     }
 
+    /**
+     * @inheritDoc
+     */
     public function setHydrator(HydratorInterface $hydrator)
     {
         return $this;
@@ -190,6 +236,9 @@ final class FieldsetInterfaceImplementation implements FieldsetInterface
         return null;
     }
 
+    /**
+     * @inheritDoc
+     */
     public function bindValues(array $values = [])
     {
         return null;
@@ -200,6 +249,9 @@ final class FieldsetInterfaceImplementation implements FieldsetInterface
         return false;
     }
 
+    /**
+     * @inheritDoc
+     */
     public function setFormFactory(Factory $formFactory)
     {
         $this->formFactory = $formFactory;


### PR DESCRIPTION

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

I found another place where implementing a custom `FieldsetInterface` breaks. `FormElementManager` does not inject the `Factory` pulled from the container, so any custom elements are unavailable.

